### PR TITLE
🐛 input 타입 에러

### DIFF
--- a/src/shared/ui/Input/index.tsx
+++ b/src/shared/ui/Input/index.tsx
@@ -42,7 +42,7 @@ const Input = forwardRef<HTMLInputElement, Props>(
             {...props}
             id={inputId}
             ref={ref}
-            type={type === 'password' ? 'text' : type}
+            type={type}
             className="w-full border-none bg-transparent text-body4 outline-none"
             style={inputStyle}
             placeholder={placeholder}


### PR DESCRIPTION
## 💡 배경 및 개요
input 타입 에러

## 📃 작업내용
input에 password type을 props로 넘겨도 type이 지정되지 않는 이슈가 있었다.

