### PR TITLE
🔀 역할 체크 추가

### DIFF
--- a/src/app/api/expo/route.ts
+++ b/src/app/api/expo/route.ts
@@ -6,13 +6,16 @@ import { apiClient } from '@/shared/libs/apiClient';
 export async function GET() {
   const cookieStore = cookies();
   const accessToken = cookieStore.get('accessToken')?.value;
+  const config = accessToken
+    ? {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      }
+    : {};
 
   try {
-    const response = await apiClient.get('/expo', {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
+    const response = await apiClient.get('/expo', config);
     return NextResponse.json(response.data);
   } catch (error) {
     const axiosError = error as AxiosError<{ message: string }>;

--- a/src/app/api/form/[expo_id]/route.ts
+++ b/src/app/api/form/[expo_id]/route.ts
@@ -11,13 +11,15 @@ export async function POST(
   const { expo_id } = params;
   const cookieStore = cookies();
   const accessToken = cookieStore.get('accessToken')?.value;
-
+  const config = accessToken
+    ? {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      }
+    : {};
   try {
-    const response = await apiClient.post(`/form/${expo_id}`, body, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
+    const response = await apiClient.post(`/form/${expo_id}`, body, config);
     return NextResponse.json(response.data);
   } catch (error) {
     const axiosError = error as AxiosError<{ message: string }>;

--- a/src/app/api/form/pre-standard/[expo_id]/route.ts
+++ b/src/app/api/form/pre-standard/[expo_id]/route.ts
@@ -11,16 +11,18 @@ export async function POST(
   const { expo_id } = params;
   const cookieStore = cookies();
   const accessToken = cookieStore.get('accessToken')?.value;
-
+  const config = accessToken
+    ? {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      }
+    : {};
   try {
     const response = await apiClient.post(
       `/form/pre-standard/${expo_id}`,
       body,
-      {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      },
+      config,
     );
     return NextResponse.json(response.data);
   } catch (error) {

--- a/src/app/api/form/standard/[expo_id]/route.ts
+++ b/src/app/api/form/standard/[expo_id]/route.ts
@@ -11,13 +11,19 @@ export async function POST(
   const { expo_id } = params;
   const cookieStore = cookies();
   const accessToken = cookieStore.get('accessToken')?.value;
-
+  const config = accessToken
+    ? {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      }
+    : {};
   try {
-    const response = await apiClient.post(`/form/standard/${expo_id}`, body, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
+    const response = await apiClient.post(
+      `/form/standard/${expo_id}`,
+      body,
+      config,
+    );
     return NextResponse.json(response.data);
   } catch (error) {
     const axiosError = error as AxiosError<{ message: string }>;

--- a/src/app/api/form/trainee/[expo_id]/route.ts
+++ b/src/app/api/form/trainee/[expo_id]/route.ts
@@ -11,13 +11,19 @@ export async function POST(
   const { expo_id } = params;
   const cookieStore = cookies();
   const accessToken = cookieStore.get('accessToken')?.value;
-
+  const config = accessToken
+    ? {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      }
+    : {};
   try {
-    const response = await apiClient.post(`/form/trainee/${expo_id}`, body, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
+    const response = await apiClient.post(
+      `/form/trainee/${expo_id}`,
+      body,
+      config,
+    );
     return NextResponse.json(response.data);
   } catch (error) {
     const axiosError = error as AxiosError<{ message: string }>;

--- a/src/app/api/standard/list/[expo_id]/route.ts
+++ b/src/app/api/standard/list/[expo_id]/route.ts
@@ -11,15 +11,20 @@ export async function POST(
   const { expo_id } = params;
   const cookieStore = cookies();
   const accessToken = cookieStore.get('accessToken')?.value;
-  console.log(expo_id);
-  console.log(accessToken);
+  const config = accessToken
+    ? {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      }
+    : {};
 
   try {
-    const response = await apiClient.post(`/standard/list/${expo_id}`, body, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
+    const response = await apiClient.post(
+      `/standard/list/${expo_id}`,
+      body,
+      config,
+    );
 
     return NextResponse.json(response.data);
   } catch (error) {

--- a/src/app/api/standard/program/[expo_id]/route.ts
+++ b/src/app/api/standard/program/[expo_id]/route.ts
@@ -10,12 +10,20 @@ export async function GET(
   const { expo_id } = params;
   const cookieStore = cookies();
   const accessToken = cookieStore.get('accessToken')?.value;
+
+  const config = accessToken
+    ? {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      }
+    : {};
+
   try {
-    const response = await apiClient.get(`/standard/program/${expo_id}`, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
+    const response = await apiClient.get(
+      `/standard/program/${expo_id}`,
+      config,
+    );
     return NextResponse.json(response.data);
   } catch (error) {
     const axiosError = error as AxiosError<{ message: string }>;

--- a/src/app/api/tokenCheck/route.ts
+++ b/src/app/api/tokenCheck/route.ts
@@ -1,0 +1,17 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  try {
+    const cookieStore = cookies();
+    const accessToken = cookieStore.get('accessToken')?.value || null;
+
+    return NextResponse.json({ accessToken });
+  } catch (error) {
+    console.error('Error fetching access token:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch access token' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/training/list/[expo_id]/route.ts
+++ b/src/app/api/training/list/[expo_id]/route.ts
@@ -13,13 +13,20 @@ export async function POST(
   const accessToken = cookieStore.get('accessToken')?.value;
   console.log(expo_id);
   console.log(accessToken);
+  const config = accessToken
+    ? {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      }
+    : {};
 
   try {
-    const response = await apiClient.post(`/training/list/${expo_id}`, body, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
+    const response = await apiClient.post(
+      `/training/list/${expo_id}`,
+      body,
+      config,
+    );
 
     return NextResponse.json(response.data);
   } catch (error) {

--- a/src/app/api/training/program/[expo_id]/route.ts
+++ b/src/app/api/training/program/[expo_id]/route.ts
@@ -10,12 +10,19 @@ export async function GET(
   const { expo_id } = params;
   const cookieStore = cookies();
   const accessToken = cookieStore.get('accessToken')?.value;
+  const config = accessToken
+    ? {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      }
+    : {};
+
   try {
-    const response = await apiClient.get(`/training/program/${expo_id}`, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
+    const response = await apiClient.get(
+      `/training/program/${expo_id}`,
+      config,
+    );
     return NextResponse.json(response.data);
   } catch (error) {
     const axiosError = error as AxiosError<{ message: string }>;

--- a/src/shared/components/ClientInitializer.tsx
+++ b/src/shared/components/ClientInitializer.tsx
@@ -1,0 +1,36 @@
+'use client';
+import axios from 'axios';
+import { useEffect, useState } from 'react';
+import useStore from '../stores/useStore';
+
+const ClientInitializer: React.FC = () => {
+  const [token, setToken] = useState<string | null>(null);
+  const setRole = useStore((state) => state.setRole);
+
+  useEffect(() => {
+    const fetchAccessToken = async () => {
+      try {
+        const response = await axios.get('/api/tokenCheck');
+        console.log('API response:', response.data);
+        setToken(response.data.accessToken);
+        console.log('AccessToken from API:', response.data.accessToken);
+      } catch (error) {
+        console.error('Error fetching access token:', error);
+      }
+    };
+
+    fetchAccessToken();
+  }, []);
+
+  useEffect(() => {
+    if (token) {
+      setRole('manage');
+    } else {
+      setRole('user');
+    }
+  }, [token, setRole]);
+
+  return null;
+};
+
+export default ClientInitializer;

--- a/src/shared/stores/useStore.ts
+++ b/src/shared/stores/useStore.ts
@@ -1,15 +1,14 @@
 import { create } from 'zustand';
 
 interface StoreState {
-  count: number;
-  increment: () => void;
-  decrement: () => void;
+  role: 'user' | 'manage';
+  setRole: (newRole: 'user' | 'manage') => void;
 }
 
 const useStore = create<StoreState>((set) => ({
-  count: 0,
-  increment: () => set((state) => ({ count: state.count + 1 })),
-  decrement: () => set((state) => ({ count: state.count - 1 })),
+  role: 'user',
+
+  setRole: (newRole: 'user' | 'manage') => set({ role: newRole }),
 }));
 
 export default useStore;

--- a/src/widgets/expo-detail/ui/ExpoActionPanel/index.tsx
+++ b/src/widgets/expo-detail/ui/ExpoActionPanel/index.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import React from 'react';
+import ClientInitializer from '@/shared/components/ClientInitializer';
+import useStore from '@/shared/stores/useStore';
 import { Button, Modal } from '@/shared/ui';
 import { ModalLayout } from '@/widgets/layout';
 import { useExpoActionPanel } from '../../model/useExpoActionPanel';
@@ -9,9 +11,9 @@ interface ExpoActionPanelProps {
   role?: 'user' | 'manage';
 }
 
-const ExpoActionPanel: React.FC<ExpoActionPanelProps> = ({
-  role = 'manage',
-}) => {
+const ExpoActionPanel: React.FC<ExpoActionPanelProps> = () => {
+  const { role } = useStore();
+
   const { isModalOpen, modalContent, openModal, closeModal } =
     useExpoActionPanel();
 
@@ -45,9 +47,11 @@ const ExpoActionPanel: React.FC<ExpoActionPanelProps> = ({
 
   return (
     <div>
+      <ClientInitializer />
+
       <div className="h-fit max-w-[210px] space-y-[26px] rounded-sm border-1 border-solid border-gray-200 p-[18px] mobile:max-w-full mobile:border-none mobile:px-[16px]">
         <p className="text-caption1 text-black mobile:hidden">
-          2024 AI광주미래교육박람회
+          2024 AI광주미래교육박람회 {role}
         </p>
         <div className="space-y-2">{getButtons()}</div>
       </div>

--- a/src/widgets/expo-detail/ui/ExpoActionPanel/index.tsx
+++ b/src/widgets/expo-detail/ui/ExpoActionPanel/index.tsx
@@ -51,7 +51,7 @@ const ExpoActionPanel: React.FC<ExpoActionPanelProps> = () => {
 
       <div className="h-fit max-w-[210px] space-y-[26px] rounded-sm border-1 border-solid border-gray-200 p-[18px] mobile:max-w-full mobile:border-none mobile:px-[16px]">
         <p className="text-caption1 text-black mobile:hidden">
-          2024 AI광주미래교육박람회 {role}
+          2024 AI광주미래교육박람회
         </p>
         <div className="space-y-2">{getButtons()}</div>
       </div>

--- a/src/widgets/layout/ui/Header/index.tsx
+++ b/src/widgets/layout/ui/Header/index.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { Logo, Navigation } from '@/entities/layout/Header';
+import ClientInitializer from '@/shared/components/ClientInitializer';
 
 const Header = () => {
   return (
     <div className="mx-auto flex w-full py-5">
+      <ClientInitializer />
       <div className="mx-auto flex w-[1200px] items-center justify-between px-5">
         <Logo />
         <Navigation />


### PR DESCRIPTION
## 💡 배경 및 개요
관리자, 유저 구분 필요
## 📃 작업내용
- accessToken 유무로 user/manage 구분
- header 컴포넌트에서 ClientInitializer 호출
- /api/tokenCheck 로 accessToken 여부 확인
- token이 있을 때 manage, 없을때 user 상태 저장
- api 호출 시 manage만 header에 accessToken 넣어서 요청
## 🎸 기타
- 일반 유저 사용 가능/불가능 api 확인 부탁드립니다