### PR TITLE
박람회 생성 캐싱 이슈 해결

### DIFF
--- a/src/widgets/create-exhibition/model/exhibitionFormHandler.ts
+++ b/src/widgets/create-exhibition/model/exhibitionFormHandler.ts
@@ -1,3 +1,4 @@
+import { QueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
 import { convertAddressToCoordinates } from '../api/convertAddressToCoordinates';
@@ -10,6 +11,7 @@ import { ExhibitionFormData } from '../types/type';
 export const handleExhibitionFormSubmit = async (
   data: ExhibitionFormData,
   router: ReturnType<typeof useRouter>,
+  queryClient: QueryClient,
 ) => {
   try {
     const coordinates = await convertAddressToCoordinates(data.address);
@@ -38,6 +40,7 @@ export const handleExhibitionFormSubmit = async (
       await createTraining(response.expoId, data.trainings);
       await createStandard(response.expoId, data.standard);
       toast.success('박람회가 생성되었습니다.');
+      await queryClient.invalidateQueries({ queryKey: ['expoList'] });
       router.push('/');
     } else {
       toast.error('박람회 생성에 실패했습니다.');

--- a/src/widgets/create-exhibition/ui/ExhibitionForm/index.tsx
+++ b/src/widgets/create-exhibition/ui/ExhibitionForm/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useFieldArray, useForm } from 'react-hook-form';
 import { toast } from 'react-toastify';
@@ -23,6 +24,7 @@ const ExhibitionForm = () => {
     watch,
   } = useForm<ExhibitionFormData>();
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   const trainingFields = useFieldArray<ExhibitionFormData>({
     control,
@@ -35,7 +37,7 @@ const ExhibitionForm = () => {
   });
 
   const onSubmit = (data: ExhibitionFormData) => {
-    handleExhibitionFormSubmit(data, router);
+    handleExhibitionFormSubmit(data, router, queryClient);
   };
 
   const showError = (message: string) => {


### PR DESCRIPTION
## 💡 배경 및 개요
박람회 시스트 조회 직후 박람회를 생성하면 캐싱의 신선 유무로 인해 생성한 박람회 조회가 안되는 이슈가 발생했다.

## 📃 작업내용
박람회 생성 캐싱 이슈를 해결 했다.
## 🔀 변경사항
tanstack-query set-invalidation 사용



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 전시회 생성 프로세스에서 데이터 무효화 및 최신 데이터 동기화 기능 추가
	- React Query를 사용한 데이터 관리 개선

- **버그 수정**
	- 전시회 생성 후 데이터 새로고침 메커니즘 강화

- **개선 사항**
	- 폼 제출 프로세스의 데이터 일관성 향상
	- 쿼리 클라이언트 통합을 통한 데이터 관리 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->