### PR TITLE
🔀 폼 생성 url 변경

### DIFF
--- a/src/views/form/create/model/formCreateRouter.ts
+++ b/src/views/form/create/model/formCreateRouter.ts
@@ -2,27 +2,33 @@ import { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.share
 
 export const formCreateRouter = ({
   id,
-  navigation,
+  type,
+  mode,
   router,
 }: {
   id: string;
-  navigation: string | null;
+  type: 'STANDARD' | 'TRAINEE';
+  mode: 'application' | 'survey';
   router: AppRouterInstance;
 }) => {
-  switch (navigation) {
-    case 'standard_application':
-      router.push(`/form/create/${id}?navigation=trainee_application`);
-      break;
-    case 'trainee_application':
-      router.push(`/form/create/${id}?navigation=standard_survey`);
-      break;
-    case 'standard_survey':
-      router.push(`/form/create/${id}?navigation=trainee_survey`);
-      break;
-    case 'trainee_survey':
-      router.push('/');
-      break;
-    default:
-      break;
+  let nextType: 'STANDARD' | 'TRAINEE' | null = null;
+  let nextMode: 'application' | 'survey' | null = null;
+
+  if (type === 'STANDARD' && mode === 'application') {
+    nextType = 'TRAINEE';
+    nextMode = 'application';
+  } else if (type === 'TRAINEE' && mode === 'application') {
+    nextType = 'STANDARD';
+    nextMode = 'survey';
+  } else if (type === 'STANDARD' && mode === 'survey') {
+    nextType = 'TRAINEE';
+    nextMode = 'survey';
+  } else if (type === 'TRAINEE' && mode === 'survey') {
+    router.push('/');
+    return;
+  }
+
+  if (nextType && nextMode) {
+    router.push(`/form/create/${id}?type=${nextType}&mode=${nextMode}`);
   }
 };

--- a/src/views/form/create/model/formUtils.ts
+++ b/src/views/form/create/model/formUtils.ts
@@ -1,13 +1,5 @@
 import { FormValues, CreateFormRequest } from '@/shared/types/form/create/type';
 
-export const getParticipantOrType = (
-  navigation?: string | null,
-): 'STANDARD' | 'TRAINEE' => {
-  return ['standard_application', 'standard_survey'].includes(navigation || '')
-    ? 'STANDARD'
-    : 'TRAINEE';
-};
-
 const convertOptionsToJson = (options: { value: string }[]): string => {
   return JSON.stringify(
     options.reduce(
@@ -22,10 +14,10 @@ const convertOptionsToJson = (options: { value: string }[]): string => {
 
 const getSurveyRequestData = (
   data: FormValues,
-  participantOrType: 'STANDARD' | 'TRAINEE',
+  type: 'STANDARD' | 'TRAINEE',
 ) => {
   return {
-    participationType: participantOrType,
+    participationType: type,
     dynamicSurveyRequestDto: data.questions.map((question) => ({
       title: question.title,
       formType: question.formType,
@@ -38,10 +30,10 @@ const getSurveyRequestData = (
 
 const getApplicationRequestData = (
   data: FormValues,
-  participantOrType: 'STANDARD' | 'TRAINEE',
+  type: 'STANDARD' | 'TRAINEE',
 ) => {
   return {
-    participantType: participantOrType,
+    participantType: type,
     dynamicForm: data.questions.map((question) => ({
       title: question.title,
       formType: question.formType,
@@ -55,13 +47,10 @@ const getApplicationRequestData = (
 
 export const transformFormData = (
   data: FormValues,
-  navigation?: string | null,
+  type: 'STANDARD' | 'TRAINEE',
+  mode: 'application' | 'survey',
 ): CreateFormRequest => {
-  const isSurvey =
-    navigation === 'standard_survey' || navigation === 'trainee_survey';
-  const participantOrType = getParticipantOrType(navigation);
-
-  return isSurvey
-    ? getSurveyRequestData(data, participantOrType)
-    : getApplicationRequestData(data, participantOrType);
+  return mode === 'survey'
+    ? getSurveyRequestData(data, type)
+    : getApplicationRequestData(data, type);
 };

--- a/src/views/form/create/model/getFormTitle.ts
+++ b/src/views/form/create/model/getFormTitle.ts
@@ -1,0 +1,17 @@
+const formTitles = {
+  STANDARD: {
+    application: '참가자 신청 폼',
+    survey: '참가자 만족도 조사 폼',
+  },
+  TRAINEE: {
+    application: '연수자 신청 폼',
+    survey: '연수자 만족도 조사 폼',
+  },
+};
+
+export const getFormTitle = (
+  type: 'STANDARD' | 'TRAINEE',
+  mode: 'application' | 'survey',
+) => {
+  return formTitles[type]?.[mode] || '폼';
+};

--- a/src/views/form/create/model/navigationTitles.ts
+++ b/src/views/form/create/model/navigationTitles.ts
@@ -1,6 +1,0 @@
-export const navigationTitles: Record<string, string> = {
-  standard_application: '참가자 신청 폼',
-  trainee_application: '연수자 신청 폼',
-  standard_survey: '참가자 만족도 조사 폼',
-  trainee_survey: '연수자 만족도 조사 폼',
-};

--- a/src/views/form/create/model/useCreateApplicationForm.ts
+++ b/src/views/form/create/model/useCreateApplicationForm.ts
@@ -7,20 +7,21 @@ import { formCreateRouter } from './formCreateRouter';
 
 export const useCreateApplicationForm = (
   id: string,
-  navigation: string | null,
+  type: 'STANDARD' | 'TRAINEE',
   router: AppRouterInstance,
+  mode: 'application' | 'survey',
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationKey: ['createApplicationForm', id, navigation],
+    mutationKey: ['createApplicationForm', id, type],
     mutationFn: (formattedData: CreateFormRequest) =>
       createApplicationForm({ data: formattedData, id }),
     onSuccess: () => {
       toast.success('신청 폼이 생성되었습니다.');
-      formCreateRouter({ id, navigation, router });
+      formCreateRouter({ id, type, mode, router });
       queryClient.resetQueries({
-        queryKey: ['createApplicationForm', id, navigation],
+        queryKey: ['createApplicationForm', id, type],
       });
     },
     onError: () => {

--- a/src/views/form/create/model/useCreateSurveyForm.ts
+++ b/src/views/form/create/model/useCreateSurveyForm.ts
@@ -7,20 +7,21 @@ import { formCreateRouter } from './formCreateRouter';
 
 export const useCreateSurveyForm = (
   id: string,
-  navigation: string | null,
+  type: 'STANDARD' | 'TRAINEE',
   router: AppRouterInstance,
+  mode: 'application' | 'survey',
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationKey: ['createSurveyForm', id, navigation],
+    mutationKey: ['createSurveyForm', id, type],
     mutationFn: (formattedData: CreateFormRequest) =>
       createSurveyForm({ data: formattedData, id }),
     onSuccess: () => {
       toast.success('만족도 조사 폼이 생성되었습니다.');
-      formCreateRouter({ id, navigation, router });
+      formCreateRouter({ id, type, mode, router });
       queryClient.resetQueries({
-        queryKey: ['createSurveyForm', id, navigation],
+        queryKey: ['createSurveyForm', id, type],
       });
     },
     onError: () => {

--- a/src/views/form/create/model/useSubmitForm.ts
+++ b/src/views/form/create/model/useSubmitForm.ts
@@ -1,33 +1,39 @@
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { FormValues } from '@/shared/types/form/create/type';
 import { transformFormData } from '../model/formUtils';
 import { useCreateApplicationForm } from './useCreateApplicationForm';
 import { useCreateSurveyForm } from './useCreateSurveyForm';
 
-export const useSubmitForm = (id: string) => {
+export const useSubmitForm = (
+  id: string,
+  type: 'STANDARD' | 'TRAINEE',
+  mode: 'application' | 'survey',
+  reset: () => void,
+) => {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const navigation = searchParams.get('navigation');
 
   const {
     mutate: createApplicationForm,
     isPending: isApplicationPending,
     isSuccess: isApplicationSuccess,
-  } = useCreateApplicationForm(id, navigation, router);
+  } = useCreateApplicationForm(id, type, router, mode);
   const {
     mutate: createSurveyForm,
     isPending: isSurveyPending,
     isSuccess: isSurveySuccess,
-  } = useCreateSurveyForm(id, navigation, router);
+  } = useCreateSurveyForm(id, type, router, mode);
 
   const handleSubmitForm = (data: FormValues) => {
-    const formattedData = transformFormData(data, navigation);
+    const formattedData = transformFormData(data, type, mode);
 
-    if (navigation === 'standard_survey' || navigation === 'trainee_survey') {
-      createSurveyForm(formattedData);
-    } else {
-      createApplicationForm(formattedData);
-    }
+    const submitFunction =
+      mode === 'survey' ? createSurveyForm : createApplicationForm;
+
+    submitFunction(formattedData, {
+      onSuccess: () => {
+        reset();
+      },
+    });
   };
 
   return {

--- a/src/views/form/create/ui/createForm/index.tsx
+++ b/src/views/form/create/ui/createForm/index.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useSearchParams } from 'next/navigation';
-import { useEffect } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
 import { toast } from 'react-toastify';
 import { CreateFormButton } from '@/entities/form/create';
@@ -10,18 +9,23 @@ import { FormValues } from '@/shared/types/form/create/type';
 import { Button, PageHeader } from '@/shared/ui';
 import FormContainer from '@/widgets/form/create/ui/FormContainer';
 import { Header } from '@/widgets/layout';
-import { navigationTitles } from '../../model/navigationTitles';
+import { getFormTitle } from '../../model/getFormTitle';
 import { selectOptionData } from '../../model/selectOptionData';
 import { useSubmitForm } from '../../model/useSubmitForm';
 
 const CreateForm = ({ id }: { id: string }) => {
-  const { control, handleSubmit, register, setValue } = useForm<FormValues>({
-    defaultValues: { questions: [] },
-  });
+  const { control, handleSubmit, register, setValue, reset } =
+    useForm<FormValues>({
+      defaultValues: { questions: [] },
+    });
   const { fields, append, remove } = useFieldArray({
     control,
     name: 'questions',
   });
+
+  const searchParams = useSearchParams();
+  const type = searchParams.get('type') as 'STANDARD' | 'TRAINEE';
+  const mode = searchParams.get('mode') as 'application' | 'survey';
 
   const {
     handleSubmitForm,
@@ -29,14 +33,7 @@ const CreateForm = ({ id }: { id: string }) => {
     isSurveyPending,
     isApplicationSuccess,
     isSurveySuccess,
-  } = useSubmitForm(id);
-
-  const searchParams = useSearchParams();
-  const navigation = searchParams.get('navigation');
-
-  useEffect(() => {
-    setValue('questions', []);
-  }, [navigation, setValue]);
+  } = useSubmitForm(id, type, mode, reset);
 
   return (
     <div className="flex h-screen flex-col gap-[30px] mobile:gap-0">
@@ -48,9 +45,7 @@ const CreateForm = ({ id }: { id: string }) => {
         )}
         className="mx-auto w-full max-w-[792px] flex-1 space-y-4 px-5 pb-5"
       >
-        <PageHeader
-          title={navigationTitles[navigation || 'standard_application']}
-        />
+        <PageHeader title={getFormTitle(type, mode)} />
         <div className="w-full space-y-8">
           {fields.map((field, index) => (
             <FormContainer

--- a/src/widgets/expo-created/ui/ExpoCreatedContainer/index.tsx
+++ b/src/widgets/expo-created/ui/ExpoCreatedContainer/index.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/shared/ui';
 const ExpoCreatedContainer = ({ id }: { id: string }) => {
   const router = useRouter();
   const handleButton = () => {
-    router.push(`/form/create/${id}?navigation=standard_application`);
+    router.push(`/form/create/${id}?type=STANDARD&mode=application`);
   };
   return (
     <div className="flex h-full w-full flex-col items-center justify-center gap-[40px]">


### PR DESCRIPTION
## 💡 배경 및 개요
- 폼 생성 url을 통일 시켜 url 별로 조건식이 복잡해지는 문제를 해결하였다.

## 📃 작업내용
ex) localhost:3000/create/form/[id]%navigation=application-trainee -> localhost:3000/create/form/[id]%type=TRAINEE&mode=survey


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 양식 페이지 제목이 선택한 유형(일반/트레이니)과 모드(지원서/설문)에 따라 동적으로 표시됩니다.
- **리팩토링**
	- 양식 생성 및 제출 흐름이 단순화되어, 유형과 모드 기반으로 경로 및 URL 처리가 개선되었습니다.
	- 불필요한 내부 로직과 중복 처리 방식이 제거되어 사용자 경험이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->