### PR TITLE
토큰 재발급 이슈 개선

### DIFF
--- a/src/app/api/server/token/[...path]/route.ts
+++ b/src/app/api/server/token/[...path]/route.ts
@@ -64,10 +64,17 @@ async function handleRequest(req: NextRequest) {
   } catch (error) {
     const axiosError = error as AxiosError<{ message: string }>;
     const status = axiosError.response?.status || 500;
+
+    if (status === 401) {
+      return NextResponse.json(
+        { error: 'Unauthorized', status: 401 },
+        { status: 401 },
+      );
+    }
+
     const message =
       axiosError.response?.data?.message ||
       '요청을 처리하는 중 오류가 발생했습니다.';
-
     return NextResponse.json({ error: message, status }, { status });
   }
 }


### PR DESCRIPTION
## 💡 배경 및 개요
토큰 재발급시 500에러가 날라와 interceptor에서 토큰이 삭제되는 이슈가 있었다.

## 📃 작업내용
401발생시 401을 캐치하고 intercptor로 넘기게 제작하였다



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 인증되지 않은 접근(401) 상황에서 사용자에게 명확한 오류 메시지를 제공하도록 오류 처리 방식을 개선하였습니다. 이는 인증 실패 시, 보다 직관적인 피드백을 전달하여 사용자 경험을 향상시킵니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->