### PR TITLE
참가자 & 연수자 액셀 다운로드

### DIFF
--- a/src/shared/model/footerActions.ts
+++ b/src/shared/model/footerActions.ts
@@ -11,10 +11,10 @@ export interface UserData {
   personalInformationStatus: string;
 }
 
-export const fileActions = (id: string | number) => ({
+export const fileActions = (id: string | number, urlPrefix: string) => ({
   exportExcel: async () => {
     try {
-      const response = await clientTokenInstance.get(`/excel/${id}`, {
+      const response = await clientTokenInstance.get(`${urlPrefix}/${id}`, {
         headers: {
           'X-File-Download': 'true',
         },

--- a/src/shared/ui/Table/TableFooter/index.tsx
+++ b/src/shared/ui/Table/TableFooter/index.tsx
@@ -17,6 +17,7 @@ type TableFooterProps = VariantProps<typeof tableFooterStyles> & {
   actions?: ActionsType;
   selectItem: number | null;
   setSelectItem: React.Dispatch<React.SetStateAction<number | null>>;
+  selectItemBoolean: boolean;
 };
 
 const tableFooterStyles = cva('flex justify-between items-center', {
@@ -42,10 +43,13 @@ const TableFooter = ({
   num,
   selectItem,
   setSelectItem,
+  selectItemBoolean,
 }: TableFooterProps) => {
   const handleActionClick = (actionKey: ActionKeys) => {
-    if (selectItem !== null && actions[actionKey]) {
-      actions[actionKey]!(selectItem);
+    const isDisabled = selectItemBoolean !== false && selectItem === null;
+
+    if (!isDisabled && actions[actionKey]) {
+      actions[actionKey]!(selectItem!);
       setSelectItem(null);
     }
   };

--- a/src/shared/ui/Table/TableForm/index.tsx
+++ b/src/shared/ui/Table/TableForm/index.tsx
@@ -13,6 +13,7 @@ interface Props<T> {
   actions?: { [key: string]: (selectItem: number) => void };
   totalPage?: number;
   id?: string;
+  selectItemBoolean?: boolean;
 }
 
 const TableForm = <T extends { id: number }>({
@@ -24,6 +25,7 @@ const TableForm = <T extends { id: number }>({
   actions,
   totalPage,
   id,
+  selectItemBoolean = true,
 }: Props<T>) => {
   const [selectItem, setSelectItem] = useState<number | null>(null);
 
@@ -38,6 +40,7 @@ const TableForm = <T extends { id: number }>({
               setState={setSelectItem}
               key={index}
               data={item}
+              selectItemBoolean={selectItemBoolean}
             />
           ))}
         </div>
@@ -55,6 +58,7 @@ const TableForm = <T extends { id: number }>({
         actions={actions}
         selectItem={selectItem}
         setSelectItem={setSelectItem}
+        selectItemBoolean={selectItemBoolean}
       />
     </div>
   );

--- a/src/shared/ui/Table/TableItem/index.tsx
+++ b/src/shared/ui/Table/TableItem/index.tsx
@@ -2,14 +2,17 @@ interface TableItemProps<T extends { id: number } & Record<string, unknown>> {
   data: T;
   state: number | null;
   setState: React.Dispatch<React.SetStateAction<number | null>>;
+  selectItemBoolean: boolean;
 }
 
 const TableItem = <T extends { id: number } & Record<string, unknown>>({
   data,
   state,
   setState,
+  selectItemBoolean,
 }: TableItemProps<T>) => {
   const handleSelectItem = (id: number) => {
+    if (!selectItemBoolean) return;
     setState((prev) => (prev === id ? null : id));
   };
 

--- a/src/widgets/expo-manage/ui/ExpoManageForm/index.tsx
+++ b/src/widgets/expo-manage/ui/ExpoManageForm/index.tsx
@@ -88,6 +88,7 @@ const ExpoManageForm = ({ id }: { id: string }) => {
             actions={fileActions(id, '/excel')}
             totalPage={totalPage}
             id={id}
+            selectItemBoolean={false}
           />
         ) : (
           <TableForm<participants>
@@ -99,6 +100,7 @@ const ExpoManageForm = ({ id }: { id: string }) => {
             actions={fileActions(id, '/excel/standard')}
             totalPage={totalPage}
             id={id}
+            selectItemBoolean={false}
           />
         )}
       </div>

--- a/src/widgets/expo-manage/ui/ExpoManageForm/index.tsx
+++ b/src/widgets/expo-manage/ui/ExpoManageForm/index.tsx
@@ -85,7 +85,7 @@ const ExpoManageForm = ({ id }: { id: string }) => {
             maxHeight="414px"
             footerType="file"
             text="참가자 전체 인원"
-            actions={fileActions(id)}
+            actions={fileActions(id, '/excel')}
             totalPage={totalPage}
             id={id}
           />
@@ -96,7 +96,7 @@ const ExpoManageForm = ({ id }: { id: string }) => {
             maxHeight="414px"
             footerType="file"
             text="참가자 전체 인원"
-            actions={fileActions(id)}
+            actions={fileActions(id, '/excel/standard')}
             totalPage={totalPage}
             id={id}
           />

--- a/src/widgets/program-detail/ui/ProgramDetailForm/index.tsx
+++ b/src/widgets/program-detail/ui/ProgramDetailForm/index.tsx
@@ -57,7 +57,7 @@ const ProgramDetailForm = ({ id }: { id: number }) => {
           maxHeight="414px"
           footerType="file"
           text="인원 수"
-          actions={fileActions(id)}
+          actions={fileActions(id, '/excel')}
         />
       </div>
     ),


### PR DESCRIPTION
## 💡 배경 및 개요
기존에 연수자만 액셀을 출력할 수 있게 되어있었다.

## 📃 작업내용
- 기존에 연수자 excel url로 고정되어있던걸 api url을 props로 받아 실행되도록 적용했다.

## 🔀 변경사항
- api url 정적 -> props로 동적으로 처리


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 엑셀 내보내기 기능에서 다양한 엔드포인트를 지원하도록 개선되었습니다. 이제 표마다 다른 경로로 엑셀 파일을 내보낼 수 있습니다.
  - 표 항목 선택 기능을 개별적으로 활성화하거나 비활성화할 수 있는 옵션이 추가되어, 필요에 따라 항목 선택을 제한할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->