### PR TITLE
만족도 조사폼 쿼리 스트링 설정

### DIFF
--- a/src/entities/application/ui/OptionContainer/index.tsx
+++ b/src/entities/application/ui/OptionContainer/index.tsx
@@ -10,6 +10,20 @@ import DropDownOption from '../DropDownOption';
 import MultipleOption from '../MultipleOption';
 import SentenceOption from '../SentenceOption';
 
+interface OptionContainerProps {
+  title: string;
+  formType: string;
+  jsonData?: string | { [key: string]: string };
+  requiredStatus: boolean;
+  otherJson: string | null;
+  type?: string;
+  register: UseFormRegister<ApplicationFormValues>;
+  watch: UseFormWatch<ApplicationFormValues>;
+  setValue: UseFormSetValue<ApplicationFormValues>;
+  readOnly?: boolean;
+  defaultValue?: string;
+}
+
 const OptionContainer = ({
   title,
   formType,
@@ -20,17 +34,9 @@ const OptionContainer = ({
   register,
   watch,
   setValue,
-}: {
-  title: string;
-  formType: string;
-  jsonData?: string | { [key: string]: string };
-  requiredStatus: boolean;
-  otherJson: string | null;
-  type?: string;
-  register: UseFormRegister<ApplicationFormValues>;
-  watch: UseFormWatch<ApplicationFormValues>;
-  setValue: UseFormSetValue<ApplicationFormValues>;
-}) => {
+  readOnly = false,
+  defaultValue = '',
+}: OptionContainerProps) => {
   const options = jsonData
     ? typeof jsonData === 'string'
       ? Object.entries(JSON.parse(jsonData)).map(([key, value]) => ({
@@ -54,6 +60,8 @@ const OptionContainer = ({
           row={1}
           required={requiredStatus}
           type={type}
+          readOnly={readOnly}
+          defaultValue={defaultValue}
         />
       );
       break;
@@ -105,13 +113,16 @@ const OptionContainer = ({
           type={type}
         />
       );
+      break;
+    default:
+      inputComponent = null;
   }
 
   return (
     <div className="flex flex-col gap-20 rounded-sm border-1 border-solid border-gray-200 p-18">
       <div className="flex items-center gap-2">
         <p className="text-h3b text-black">{title}</p>
-        {requiredStatus ? <p className="text-main-600">*</p> : null}
+        {requiredStatus && <p className="text-main-600">*</p>}
       </div>
       <div className="space-y-10">{inputComponent}</div>
     </div>

--- a/src/entities/application/ui/SentenceOption/index.tsx
+++ b/src/entities/application/ui/SentenceOption/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useEffect } from 'react';
 import { UseFormRegister } from 'react-hook-form';
 import { ApplicationFormValues } from '@/shared/types/application/type';
 
@@ -9,6 +9,8 @@ interface Props {
   register: UseFormRegister<ApplicationFormValues>;
   name: string;
   type?: string;
+  readOnly?: boolean;
+  defaultValue?: string;
 }
 
 export default function SentenceOption({
@@ -18,17 +20,29 @@ export default function SentenceOption({
   register,
   name,
   type,
+  readOnly = false,
+  defaultValue = '',
 }: Props) {
   const { ref, onChange, ...rest } = register(name, {
     required: required ? '필수 옵션을 작성해주세요' : false,
   });
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
+  useEffect(() => {
+    if (readOnly && textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+      textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
+      textareaRef.current.value = defaultValue;
+    }
+  }, [readOnly, defaultValue]);
+
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto';
       textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
     }
+
+    if (readOnly) return;
 
     let value = e.target.value;
 
@@ -55,6 +69,8 @@ export default function SentenceOption({
           maxLength={maxLength}
           onChange={handleChange}
           placeholder={name}
+          readOnly={readOnly}
+          defaultValue={defaultValue}
           {...rest}
         />
       </div>

--- a/src/widgets/application/ui/ApplicationLayout/index.tsx
+++ b/src/widgets/application/ui/ApplicationLayout/index.tsx
@@ -26,6 +26,8 @@ const ApplicationLayout = ({ params }: { params: string }) => {
   const applicationType = searchParams.get('applicationType') as
     | 'register'
     | 'onsite';
+  const phoneNumber = searchParams.get('phoneNumber');
+
   const { register, handleSubmit, watch, setValue } =
     useForm<ApplicationFormValues>();
 
@@ -126,6 +128,8 @@ const ApplicationLayout = ({ params }: { params: string }) => {
                 register={register}
                 watch={watch}
                 setValue={setValue}
+                readOnly={formType === 'survey' && !!phoneNumber}
+                defaultValue={phoneNumber ?? ''}
               />
             )}
 


### PR DESCRIPTION
## 💡 배경 및 개요
만족도 조사폼 쿼리 스트링 설정

## 📃 작업내용
만족도 조사폼 쿼리 스트링 설정



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - URL의 phoneNumber 파라미터를 통해 전화번호 입력란이 자동으로 채워집니다.
  - 설문(form type이 'survey')일 경우, URL에 phoneNumber가 있으면 해당 입력란이 읽기 전용으로 표시됩니다.

- **개선 사항**
  - 전화번호 입력란의 읽기 전용 및 기본값 설정 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->