### PR TITLE
feat: LRUCache => redis 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "axios": "^1.7.7",
         "class-variance-authority": "^0.7.0",
         "date-fns": "^4.1.0",
+        "ioredis": "^5.6.1",
         "lru-cache": "^11.1.0",
         "next": "^14.2.28",
         "qrcode.react": "^4.1.0",
@@ -23,6 +24,7 @@
         "react-kakao-maps-sdk": "^1.1.27",
         "react-qr-code": "^2.0.15",
         "react-toastify": "^10.0.6",
+        "redlock": "^5.0.0-beta.2",
         "tailwindcss-animate": "^1.0.7",
         "zustand": "^5.0.0"
       },
@@ -3009,6 +3011,12 @@
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -7022,6 +7030,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -7494,7 +7511,6 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -7628,6 +7644,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -10326,6 +10351,30 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.6.1.tgz",
+      "integrity": "sha512-UxC0Yv1Y4WRJiGQxQkP0hfdL0/5/6YvdfOOClRgJ0qppSarkhneSa6UvkMkms0AkdGimSH3Ikqm+6mkMmX7vGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -11339,6 +11388,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -11823,7 +11884,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -11972,7 +12032,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
       "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-polyfill-webpack-plugin": {
@@ -13636,6 +13695,39 @@
         "node": ">=8"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redlock": {
+      "version": "5.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/redlock/-/redlock-5.0.0-beta.2.tgz",
+      "integrity": "sha512-2RDWXg5jgRptDrB1w9O/JgSZC0j7y4SlaXnor93H/UJm/QyDiFgBKNtrh0TI6oCXqYSaSoXxFh6Sd3VtYfhRXw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-abort-controller": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.6.tgz",
@@ -14604,6 +14696,12 @@
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
     },
     "node_modules/statuses": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "axios": "^1.7.7",
     "class-variance-authority": "^0.7.0",
     "date-fns": "^4.1.0",
+    "ioredis": "^5.6.1",
     "lru-cache": "^11.1.0",
     "next": "^14.2.28",
     "qrcode.react": "^4.1.0",
@@ -30,6 +31,7 @@
     "react-kakao-maps-sdk": "^1.1.27",
     "react-qr-code": "^2.0.15",
     "react-toastify": "^10.0.6",
+    "redlock": "^5.0.0-beta.2",
     "tailwindcss-animate": "^1.0.7",
     "zustand": "^5.0.0"
   },

--- a/src/app/api/auth/signin/route.ts
+++ b/src/app/api/auth/signin/route.ts
@@ -6,28 +6,24 @@ import { SignInData } from '@/shared/types/signin/type';
 
 export async function POST(request: Request) {
   const body: SignInData = await request.json();
-
   try {
-    const response = await serverInstance.post('/auth/signin', body);
+    const { data } = await serverInstance.post('/auth/signin', body);
 
-    const accessTokenExpires = new Date(response.data.accessTokenExpiresIn);
-    const refreshTokenExpires = new Date(response.data.refreshTokenExpiresIn);
+    const accessTokenExpires = new Date(data.accessTokenExpiresIn + 'Z');
+    const refreshTokenExpires = new Date(data.refreshTokenExpiresIn + 'Z');
 
     setAuthCookies({
-      accessToken: response.data.accessToken,
-      refreshToken: response.data.refreshToken,
+      accessToken: data.accessToken,
+      refreshToken: data.refreshToken,
       accessTokenExpires,
       refreshTokenExpires,
     });
-
-    return NextResponse.json(response.data);
+    return NextResponse.json(data);
   } catch (error) {
     const axiosError = error as AxiosError<{ message: string }>;
-
     const status = axiosError.response?.status || 500;
     const message =
       axiosError.response?.data?.message || '로그인에 실패했습니다.';
-
     return NextResponse.json({ error: message, status }, { status });
   }
 }

--- a/src/shared/libs/cookie/setAuthCookies.ts
+++ b/src/shared/libs/cookie/setAuthCookies.ts
@@ -12,14 +12,12 @@ export function setAuthCookies({
   refreshTokenExpires: Date;
 }) {
   const cookieStore = cookies();
-
   cookieStore.set('accessToken', accessToken, {
     httpOnly: true,
     secure: true,
     expires: accessTokenExpires,
     sameSite: 'strict',
   });
-
   cookieStore.set('refreshToken', refreshToken, {
     httpOnly: true,
     secure: true,

--- a/src/shared/libs/handler/error.ts
+++ b/src/shared/libs/handler/error.ts
@@ -1,67 +1,32 @@
 import { AxiosError } from 'axios';
 import { NextRequest, NextResponse } from 'next/server';
-import { deleteAuthCookies } from '@/shared/libs/cookie/deleteCookies';
+import { deleteAuthCookies } from '../cookie/deleteCookies';
 import { retryRequest } from './request';
 import { createErrorResponse } from './response';
-import { performTokenRefresh, getRefreshStateForUser } from './token';
+import { performTokenRefresh } from './token';
 
 export async function handleError(
   error: unknown,
   req: NextRequest,
   isRetry: boolean,
-  refreshToken: string | undefined,
+  refreshToken?: string,
   originalBody?: string | FormData,
 ): Promise<NextResponse> {
   const axiosError = error as AxiosError<{ message: string }>;
   const status = axiosError.response?.status || 500;
 
-  if (status === 401 && !isRetry) {
-    return handleTokenError(req, refreshToken, originalBody);
+  if (status === 401 && !isRetry && refreshToken) {
+    const newTokens = await performTokenRefresh(refreshToken);
+    if (newTokens) {
+      return retryRequest(req, newTokens.accessToken, originalBody);
+    } else {
+      const res = createErrorResponse('토큰 갱신에 실패했습니다.', 401, true);
+      return deleteAuthCookies(res);
+    }
   }
 
   return createErrorResponse(
-    axiosError.response?.data?.['message'] ||
-      '요청을 처리하는 중 오류가 발생했습니다.',
+    axiosError.response?.data?.message || '요청 처리 중 오류가 발생했습니다.',
     status,
   );
-}
-
-async function handleTokenError(
-  req: NextRequest,
-  refreshToken: string | undefined,
-  originalBody?: string | FormData,
-): Promise<NextResponse> {
-  if (!refreshToken) {
-    const response = createErrorResponse(
-      '토큰 갱신에 실패했습니다.',
-      401,
-      true,
-    );
-    return deleteAuthCookies(response);
-  }
-
-  const refreshState = getRefreshStateForUser(refreshToken);
-
-  if (refreshState.isRefreshing) {
-    return new Promise<NextResponse>((resolve, reject) => {
-      refreshState.waitingRequests.push({
-        resolve,
-        reject,
-        req,
-        originalBody,
-      });
-    });
-  }
-
-  const newTokens = await performTokenRefresh(refreshToken, refreshState);
-  if (newTokens) {
-    return retryRequest(req, newTokens.accessToken, originalBody);
-  } else {
-    const response = createErrorResponse(
-      '토큰 갱신에 실패했습니다.',
-      401,
-      true,
-    );
-    return deleteAuthCookies(response);
-  }
 }

--- a/src/shared/libs/handler/refreshAccessToken.ts
+++ b/src/shared/libs/handler/refreshAccessToken.ts
@@ -16,11 +16,14 @@ export async function refreshAccessToken(
       refreshTokenExpiresIn,
     } = response.data;
 
+    const accessTokenExpires = new Date(accessTokenExpiresIn + 'Z');
+    const refreshTokenExpires = new Date(refreshTokenExpiresIn + 'Z');
+
     setAuthCookies({
       accessToken,
       refreshToken: newRefreshToken,
-      accessTokenExpires: new Date(accessTokenExpiresIn),
-      refreshTokenExpires: new Date(refreshTokenExpiresIn),
+      accessTokenExpires,
+      refreshTokenExpires,
     });
 
     return { accessToken, refreshToken: newRefreshToken };

--- a/src/shared/libs/handler/request.ts
+++ b/src/shared/libs/handler/request.ts
@@ -80,5 +80,5 @@ export async function retryRequest(
     body: body && typeof body === 'string' ? body : undefined,
   });
 
-  return tokenHandleRequest(newReq, true, body);
+  return tokenHandleRequest(newReq, body);
 }

--- a/src/shared/libs/redis/lock.ts
+++ b/src/shared/libs/redis/lock.ts
@@ -1,0 +1,11 @@
+import Redlock, { Lock } from 'redlock';
+import { redis } from './redis';
+
+export const redlock = new Redlock([redis], {
+  driftFactor: 0.01,
+  retryCount: 5,
+  retryDelay: 200,
+  retryJitter: 200,
+});
+
+export type RedlockLock = Lock;

--- a/src/shared/libs/redis/redis.ts
+++ b/src/shared/libs/redis/redis.ts
@@ -1,0 +1,6 @@
+import Redis from 'ioredis';
+
+export const redis = new Redis({
+  host: process.env.REDIS_HOST,
+  port: Number(process.env.REDIS_PORT),
+});

--- a/src/shared/types/redlock.d.ts
+++ b/src/shared/types/redlock.d.ts
@@ -1,0 +1,30 @@
+declare module 'redlock' {
+  import { EventEmitter } from 'events';
+  import { Redis } from 'ioredis';
+
+  export interface Lock {
+    resource: string;
+    value: string;
+    expiration: number;
+    extend(ttl: number): Promise<Lock>;
+    release(): Promise<void>;
+  }
+
+  interface RedlockOptions {
+    driftFactor?: number;
+    retryCount?: number;
+    retryDelay?: number;
+    retryJitter?: number;
+    automaticExtensionThreshold?: number;
+  }
+
+  export default class Redlock extends EventEmitter {
+    constructor(clients: Redis[], options?: RedlockOptions);
+    acquire(resource: string | string[], ttl: number): Promise<Lock>;
+    using<T>(
+      resource: string | string[],
+      ttl: number,
+      fn: () => Promise<T>,
+    ): Promise<T>;
+  }
+}


### PR DESCRIPTION
## 💡 배경 및 개요
- Vercel 혹은 ALB + Auto‑Scaling 환경에서 인스턴스별 in‑memory LRUCache를 쓰면, 여러 인스턴스가 독립적으로 동작하며 토큰 재발급을 조율하지 못함  
- 결과적으로 동시 401 요청이 몰릴 때 각 인스턴스가 중복 리프레시 API를 호출하거나, 대기 로직이 동작하지 않아 race condition 발생

## 📃 작업내용
- **LRUCache → Redis 분산 캐시**로 대체  
- **Redlock** 라이브러리를 이용해 분산 락 획득/해제 로직 추가  
- `performTokenRefresh()`에 아래 로직 구현  
  1. 락 TTL을 5초(`TOKEN_TTL_SEC = 5`)로 설정  
  2. 락 획득 후 Redis에서 `accessToken`·`refreshToken` 조회(`hmget`)  
  3. 캐시 miss 시 실제 `/auth` API 호출 후, `hmset` + `expire(5s)`  
  4. 락 해제  
  5. 락 획득 실패(재시도 모두 실패) 시, 100ms 간격 최대 1초 동안 폴링(`hmget`)으로 캐시 대기  

## 🔀 변경사항
- **`shared/libs/redis/redis.ts`**  
  ```ts
  import Redis from 'ioredis';
  export const redis = new Redis({ host: process.env.REDIS_HOST, port: Number(process.env.REDIS_PORT) });
  ```
- **`shared/libs/redis/lock.ts`**  
  ```ts
  import Redlock, { Lock } from 'redlock';
  import { redis } from './redis';
  
  export const redlock = new Redlock([redis], {
    driftFactor: 0.01,
    retryCount: 5,
    retryDelay: 200,
    retryJitter: 200,
  });
  export type RedlockLock = Lock;
  ```
- **`shared/libs/handler/token.ts`**  
  - `performTokenRefresh()` 전체 구현을 위 캡션 로직으로 교체  
  - `TOKEN_TTL_SEC = 5`, `POLL_INTERVAL_MS = 100`, `MAX_POLL_MS = 1000` 적용  
  - 락 획득(`acquire`), 캐시 조회/저장(`hmget`/`hmset`+`expire`), 예외 시 폴링 로직  

## 🙋‍♂️ 질문사항
- TTL = 5초, `retryCount=5`, `retryDelay=200ms` 설정이 평균 150ms 백엔드 응답 환경에서 적절할까요?  
- Redis 클러스터나 네트워크 장애 상황에서 Redlock 동작 보장을 위해 추가로 고려해야 할 점이 있을까요?

## 🍴 사용방법
1. `npm install ioredis redlock`  
2. 환경 변수 설정: `REDIS_HOST`, `REDIS_PORT`  
3. `shared/libs/redis/redis.ts` / `shared/libs/redis/lock.ts` 추가  
4. `performTokenRefresh()`가 포함된 `shared/libs/handler/token.ts` 업데이트  
5. 프로덕션에서는 PM2 클러스터 모드로 워커 프로세스 다중화 권장  
   ```bash
   pm2 start npm --name api -- start -i max
   ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 분산 환경에서의 인증 토큰 갱신을 위해 Redis 기반의 분산 락과 캐시 기능이 도입되었습니다.
  - Redis 및 Redlock 관련 패키지가 추가되고, Redis 클라이언트가 새롭게 구성되었습니다.

- **Refactor**
  - 인증 토큰 갱신 및 에러 처리 로직이 단순화되고, 기존의 메모리 기반 동시성 제어가 분산 락 방식으로 변경되었습니다.
  - 토큰 처리 함수 및 관련 요청 처리 흐름이 보다 직관적으로 개선되었습니다.

- **Style**
  - 불필요한 공백 및 코드 정리가 일부 파일에 적용되었습니다.

- **Documentation**
  - Redlock 타입 선언이 추가되어 타입 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->