### PR TITLE
Fix/image error status

### DIFF
--- a/src/shared/libs/handler/error.ts
+++ b/src/shared/libs/handler/error.ts
@@ -1,30 +1,10 @@
 import { AxiosError } from 'axios';
-import { NextRequest, NextResponse } from 'next/server';
-import { deleteAuthCookies } from '../cookie/deleteCookies';
-import { retryRequest } from './request';
+import { NextResponse } from 'next/server';
 import { createErrorResponse } from './response';
-import { performTokenRefresh } from './token';
 
-export async function handleError(
-  error: unknown,
-  req: NextRequest,
-  isRetry: boolean,
-  refreshToken?: string,
-  originalBody?: string | FormData,
-): Promise<NextResponse> {
+export async function handleError(error: unknown): Promise<NextResponse> {
   const axiosError = error as AxiosError<{ message: string }>;
-  console.log(axiosError);
   const status = axiosError.response?.status || 500;
-
-  if (status === 401 && !isRetry && refreshToken) {
-    const newTokens = await performTokenRefresh(refreshToken);
-    if (newTokens) {
-      return retryRequest(req, newTokens.accessToken, originalBody);
-    } else {
-      const res = createErrorResponse('토큰 갱신에 실패했습니다.', 401, true);
-      return deleteAuthCookies(res);
-    }
-  }
 
   return createErrorResponse(
     axiosError.response?.data?.message || '요청 처리 중 오류가 발생했습니다.',

--- a/src/shared/libs/handler/tokenHandler.ts
+++ b/src/shared/libs/handler/tokenHandler.ts
@@ -69,6 +69,6 @@ export async function tokenHandleRequest(
       }
     }
 
-    return handleError(err, req, false, refreshToken, originalBody);
+    return handleError(err);
   }
 }


### PR DESCRIPTION
## 💡 배경 및 개요

`multipart/form-data`로 이미지 업로드 시, 유효하지 않은 확장자(`jpg`, `jpeg`, `png` 외)를 업로드하면 서버가 `401` 응답을 내려 클라이언트에서 `refreshToken`까지 삭제되는 문제가 발생함.  
이는 accessToken 만료 시 재발급 후 요청 재시도가 실패했을 때 무조건 쿠키를 삭제하는 기존 로직 때문임.  

## 📃 작업내용

- `tokenHandleRequest` 내부에서 accessToken 재발급 후 재시도 실패 시, 상태 코드가 `401`이 아닌 경우에는 `refreshToken`을 삭제하지 않도록 변경
- 에러 메시지를 "토큰 재발급 후 재시도 실패"에서 "인증은 성공했지만 요청 처리 중 문제가 발생했습니다."로 명확하게 수정
- `handleError` 내부에서 중복된 토큰 재발급 로직 제거 및 역할 정리 (단순 응답 생성 전용으로 정리)
- `handleError` 호출부 파라미터 개수 축소 (`refreshToken`, `originalBody` 제거)

## 🔀 변경사항

- `libs/handler/tokenHandler.ts`  
  - 재발급 후 요청 재시도 실패 시 상태 코드 확인 로직 추가
  - 불필요한 `handleError` 파라미터 정리
- `libs/handler/error.ts`  
  - `refreshToken` 관련 재발급 로직 제거
  - 에러 메시지 처리만 담당하도록 정리

## 🙋‍♂️ 질문사항

- `doRequest` 내 응답 실패를 로깅 수준에서 더 구체화해야 할 필요가 있을까요?
- 토큰 재발급 후 실패 시 fallback 응답(`400` vs `500`) 기준이 모호할 수 있는데, 명확한 기준이 필요할까요?

## 🍴 사용방법

- 프론트엔드에서 `multipart/form-data` 업로드 시 accessToken이 만료되어도 refreshToken은 더 이상 삭제되지 않음
- 허용되지 않은 이미지 확장자를 업로드하면 `400 Bad Request`로 응답됨


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 오류 처리 방식이 간소화되어, 인증 토큰 갱신 및 재시도 관련 로직이 제거되었습니다.
  - 오류 발생 시 보다 단순화된 에러 응답이 반환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->