### PR TITLE
amplify 설정 변경

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,9 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
-  experimental: {
-    serverActions: true,
-  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## 💡 배경 및 개요
amplify 설정 변경
기존에 서버액선 true로 되어있었는데 next js14부턴 이러한 옵션을 제거해도 된다

## 📃 작업내용
amplify 설정 변경




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Next.js 설정에서 `experimental.serverActions` 옵션이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->