### PR TITLE
폼 제출 형식 변경

### DIFF
--- a/src/entities/application/ui/CheckBoxOption/index.tsx
+++ b/src/entities/application/ui/CheckBoxOption/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { UseFormRegister, UseFormWatch } from 'react-hook-form';
+import { UseFormRegister } from 'react-hook-form';
 import { ApplicationFormValues } from '@/shared/types/application/type';
 import EtcOption from '../EtcOption';
 
@@ -11,7 +11,6 @@ interface Option {
 interface Props {
   options: Option[];
   register: UseFormRegister<ApplicationFormValues>;
-  watch: UseFormWatch<ApplicationFormValues>;
   name: string;
   required: boolean;
   otherJson: string | null;
@@ -19,7 +18,6 @@ interface Props {
 const CheckBoxOption = ({
   options,
   register,
-  watch,
   name,
   required,
   otherJson,
@@ -50,12 +48,7 @@ const CheckBoxOption = ({
         );
       })}
       {otherJson !== null && (
-        <EtcOption
-          register={register}
-          watch={watch}
-          name={name}
-          type="checkbox"
-        />
+        <EtcOption register={register} name={name} type="checkbox" />
       )}
     </>
   );

--- a/src/entities/application/ui/EtcOption/index.tsx
+++ b/src/entities/application/ui/EtcOption/index.tsx
@@ -9,12 +9,7 @@ interface Props {
   name: string;
 }
 
-const EtcOption = ({ type, register, watch, name }: Props) => {
-  const watchedValue = watch(name);
-  const isEtcSelected = Array.isArray(watchedValue)
-    ? watchedValue.includes('etc')
-    : watchedValue === 'etc';
-
+const EtcOption = ({ type, register, name }: Props) => {
   const inputId = `${name}-etc-option`;
 
   return (
@@ -23,26 +18,15 @@ const EtcOption = ({ type, register, watch, name }: Props) => {
         id={inputId}
         type={type}
         className="h-16 w-16"
-        value="etc"
+        value="기타"
         {...register(name)}
       />
-      <div className="flex items-center gap-10">
-        <label
-          htmlFor={inputId}
-          className="text-body3 cursor-pointer text-nowrap text-black"
-        >
-          기타
-        </label>
-        <input
-          type="text"
-          placeholder="(직접입력)"
-          className={`text-body3 w-full min-w-0 text-black ${isEtcSelected ? '' : 'bg-transparent'}`}
-          {...register(`${name}_etc`, {
-            required: isEtcSelected ? '기타를 입력해야 합니다.' : false,
-          })}
-          disabled={!isEtcSelected}
-        />
-      </div>
+      <label
+        htmlFor={inputId}
+        className="text-body3 cursor-pointer text-nowrap text-black"
+      >
+        기타
+      </label>
     </div>
   );
 };

--- a/src/entities/application/ui/EtcOption/index.tsx
+++ b/src/entities/application/ui/EtcOption/index.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { UseFormRegister, UseFormWatch } from 'react-hook-form';
+import { UseFormRegister } from 'react-hook-form';
 import { ApplicationFormValues } from '@/shared/types/application/type';
 
 interface Props {
   type: 'radio' | 'checkbox';
   register: UseFormRegister<ApplicationFormValues>;
-  watch: UseFormWatch<ApplicationFormValues>;
   name: string;
 }
 

--- a/src/entities/application/ui/MultipleOption/index.tsx
+++ b/src/entities/application/ui/MultipleOption/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { UseFormRegister, UseFormWatch } from 'react-hook-form';
+import { UseFormRegister } from 'react-hook-form';
 import { ApplicationFormValues } from '@/shared/types/application/type';
 import EtcOption from '../EtcOption';
 
@@ -11,7 +11,6 @@ interface Option {
 interface Props {
   options: Option[];
   register: UseFormRegister<ApplicationFormValues>;
-  watch: UseFormWatch<ApplicationFormValues>;
   name: string;
   required: boolean;
   otherJson: string | null;
@@ -20,7 +19,6 @@ interface Props {
 const MultipleOption = ({
   options,
   register,
-  watch,
   name,
   required,
   otherJson,
@@ -51,7 +49,7 @@ const MultipleOption = ({
         );
       })}
       {otherJson !== null && (
-        <EtcOption register={register} watch={watch} name={name} type="radio" />
+        <EtcOption register={register} name={name} type="radio" />
       )}
     </>
   );

--- a/src/entities/application/ui/OptionContainer/index.tsx
+++ b/src/entities/application/ui/OptionContainer/index.tsx
@@ -76,7 +76,6 @@ const OptionContainer = ({
           name={safeName}
           required={requiredStatus}
           otherJson={otherJson}
-          watch={watch}
         />
       );
       break;
@@ -88,7 +87,6 @@ const OptionContainer = ({
           name={safeName}
           required={requiredStatus}
           otherJson={otherJson}
-          watch={watch}
         />
       );
       break;

--- a/src/entities/application/ui/OptionContainer/index.tsx
+++ b/src/entities/application/ui/OptionContainer/index.tsx
@@ -3,6 +3,7 @@ import {
   UseFormSetValue,
   UseFormWatch,
 } from 'react-hook-form';
+import { slugify } from '@/shared/model/slugify';
 import { ApplicationFormValues } from '@/shared/types/application/type';
 import ApplicationPhoneOption from '../ApplicationPhoneOption';
 import CheckBoxOption from '../CheckBoxOption';
@@ -37,6 +38,8 @@ const OptionContainer = ({
   readOnly = false,
   defaultValue = '',
 }: OptionContainerProps) => {
+  const safeName = slugify(title);
+
   const options = jsonData
     ? typeof jsonData === 'string'
       ? Object.entries(JSON.parse(jsonData)).map(([key, value]) => ({
@@ -55,7 +58,7 @@ const OptionContainer = ({
       inputComponent = (
         <SentenceOption
           register={register}
-          name={title}
+          name={safeName}
           maxLength={20}
           row={1}
           required={requiredStatus}
@@ -70,7 +73,7 @@ const OptionContainer = ({
         <CheckBoxOption
           options={options}
           register={register}
-          name={title}
+          name={safeName}
           required={requiredStatus}
           otherJson={otherJson}
           watch={watch}
@@ -82,7 +85,7 @@ const OptionContainer = ({
         <MultipleOption
           options={options}
           register={register}
-          name={title}
+          name={safeName}
           required={requiredStatus}
           otherJson={otherJson}
           watch={watch}
@@ -94,7 +97,7 @@ const OptionContainer = ({
         <DropDownOption
           options={options}
           register={register}
-          name={title}
+          name={safeName}
           required={requiredStatus}
           setValue={setValue}
         />
@@ -104,7 +107,7 @@ const OptionContainer = ({
       inputComponent = (
         <ApplicationPhoneOption
           register={register}
-          name={title}
+          name={safeName}
           maxLength={20}
           row={1}
           required={requiredStatus}

--- a/src/entities/application/ui/OptionContainer/index.tsx
+++ b/src/entities/application/ui/OptionContainer/index.tsx
@@ -59,7 +59,7 @@ const OptionContainer = ({
         <SentenceOption
           register={register}
           name={safeName}
-          maxLength={20}
+          maxLength={500}
           row={1}
           required={requiredStatus}
           type={type}

--- a/src/shared/model/slugify.ts
+++ b/src/shared/model/slugify.ts
@@ -1,0 +1,8 @@
+export const slugify = (text: string): string => {
+  return text
+    .toLowerCase()
+    .replace(/\s+/g, '-') // 공백 → 하이픈
+    .replace(/[^\wㄱ-ㅎㅏ-ㅣ가-힣-]/g, '') // 특수문자 제거 (한글 제외)
+    .replace(/--+/g, '-') // 중복 하이픈 제거
+    .replace(/^-+|-+$/g, ''); // 앞뒤 하이픈 제거
+};

--- a/src/widgets/application/model/createStandardApplicationFormatter.ts
+++ b/src/widgets/application/model/createStandardApplicationFormatter.ts
@@ -1,3 +1,4 @@
+import { slugify } from '@/shared/model/slugify';
 import {
   DynamicFormItem,
   DynamicFormValues,
@@ -12,14 +13,17 @@ export const createStandardApplicationFormatter = (
   return (
     data: DynamicFormValues & { privacyConsent: boolean },
   ): FormattedApplicationData => {
-    const name = String(data['이름을 입력하세요'] || '');
+    const nameKey = slugify('이름을 입력하세요');
+    const phoneNumberKey = slugify('휴대폰 번호를 입력하세요');
+
+    const name = String(data[nameKey] || '');
 
     const phoneNumberStatus = data['phoneNumberStatus'];
     const includePhoneNumber =
       applicationType !== 'onsite' || phoneNumberStatus === 'true';
 
     const phoneNumber = includePhoneNumber
-      ? String(data['휴대폰 번호를 입력하세요'] || '')
+      ? String(data[phoneNumberKey] || '')
       : '';
 
     const informationJson = JSON.stringify(

--- a/src/widgets/application/model/createSurveyFormatter.ts
+++ b/src/widgets/application/model/createSurveyFormatter.ts
@@ -1,3 +1,4 @@
+import { slugify } from '@/shared/model/slugify';
 import {
   DynamicFormItem,
   DynamicFormValues,
@@ -10,9 +11,15 @@ export const createSurveyFormatter = (
 ): ((
   data: DynamicFormValues & { privacyConsent: boolean },
 ) => FormattedSurveyData) => {
-  return (data) => ({
-    phoneNumber: String(data['휴대폰 번호를 입력하세요'] || ''),
-    answerJson: JSON.stringify(processDynamicFormData(data, dynamicFormItems)),
-    personalInformationStatus: data.privacyConsent,
-  });
+  return (data) => {
+    const phoneNumberKey = slugify('휴대폰 번호를 입력하세요');
+
+    return {
+      phoneNumber: String(data[phoneNumberKey] || ''),
+      answerJson: JSON.stringify(
+        processDynamicFormData(data, dynamicFormItems),
+      ),
+      personalInformationStatus: data.privacyConsent,
+    };
+  };
 };

--- a/src/widgets/application/model/createTraineeApplicationFormatter.ts
+++ b/src/widgets/application/model/createTraineeApplicationFormatter.ts
@@ -1,3 +1,4 @@
+import { slugify } from '@/shared/model/slugify';
 import {
   DynamicFormItem,
   DynamicFormValues,
@@ -11,9 +12,9 @@ export const createTraineeApplicationFormatter = (
   return (
     data: DynamicFormValues & { privacyConsent: boolean },
   ): FormattedApplicationData => ({
-    name: String(data['이름을 입력하세요'] || ''),
-    phoneNumber: String(data['휴대폰 번호를 입력하세요'] || ''),
-    trainingId: String(data['연수원 아이디를 입력하세요'] || ''),
+    name: String(data[slugify('이름을 입력하세요')] || ''),
+    phoneNumber: String(data[slugify('휴대폰 번호를 입력하세요')] || ''),
+    trainingId: String(data[slugify('연수원 아이디를 입력하세요')] || ''),
     informationJson: JSON.stringify(
       processDynamicFormData(data, dynamicFormItems),
     ),

--- a/src/widgets/application/model/processDynamicFormData.ts
+++ b/src/widgets/application/model/processDynamicFormData.ts
@@ -1,3 +1,4 @@
+import { slugify } from '@/shared/model/slugify';
 import {
   DynamicFormItem,
   DynamicFormValues,
@@ -9,7 +10,8 @@ export const processDynamicFormData = (
   dynamicFormItems: DynamicFormItem[],
 ): Record<string, string> => {
   return dynamicFormItems.reduce<Record<string, string>>((acc, form) => {
-    const value = data[form.title];
+    const slug = slugify(form.title); // 👈 폼 등록 시 사용한 키로 접근
+    const value = data[slug]; // 👈 slugified key로 접근
     acc[form.title] = processFormField(form.title, value, form.formType, data);
     return acc;
   }, {});

--- a/src/widgets/application/model/processDynamicFormData.ts
+++ b/src/widgets/application/model/processDynamicFormData.ts
@@ -10,9 +10,9 @@ export const processDynamicFormData = (
   dynamicFormItems: DynamicFormItem[],
 ): Record<string, string> => {
   return dynamicFormItems.reduce<Record<string, string>>((acc, form) => {
-    const slug = slugify(form.title); // 👈 폼 등록 시 사용한 키로 접근
-    const value = data[slug]; // 👈 slugified key로 접근
-    acc[form.title] = processFormField(form.title, value, form.formType, data);
+    const slug = slugify(form.title);
+    const value = data[slug];
+    acc[form.title] = processFormField(form.title, value, form.formType);
     return acc;
   }, {});
 };

--- a/src/widgets/application/model/processFormField.ts
+++ b/src/widgets/application/model/processFormField.ts
@@ -1,10 +1,7 @@
-import { DynamicFormValues } from '@/shared/types/application/type';
-
 export const processFormField = (
   title: string,
   value: unknown,
   formType: string,
-  allData: DynamicFormValues,
 ): string => {
   if (
     value === undefined ||
@@ -17,17 +14,7 @@ export const processFormField = (
 
   if (formType === 'CHECKBOX' || formType === 'MULTIPLE') {
     const selectedOptions = Array.isArray(value) ? value : [value];
-    return selectedOptions
-      .map((option) =>
-        option === 'etc'
-          ? `기타: ${
-              Array.isArray(allData[`${title}_etc`])
-                ? (allData[`${title}_etc`] as string[]).join(', ')
-                : allData[`${title}_etc`] || ''
-            }`
-          : String(option),
-      )
-      .join(', ');
+    return selectedOptions.map(String).join(', ');
   }
 
   return String(value || '').toUpperCase();


### PR DESCRIPTION
## 💡 배경 및 개요

폼 필드의 이름(`name`)으로 한글, 공백, 특수문자가 포함된 `title` 문자열을 그대로 사용하면서
React Hook Form 내부에서 `_f` 관련 오류 및 렌더링 문제가 발생하던 상황.
이를 해결하기 위해 모든 필드 키를 `slugify`를 통해 안전하게 처리하고,
폼 제출 시 원래 `title` 기준으로 역매핑하여 전송 형식을 유지하도록 수정.


## 📃 작업내용

* `OptionContainer`에서 `register(slugify(title))`로 name 등록 방식 변경
* `SentenceOption`, `DropDownOption`, `CheckBoxOption` 등 관련 컴포넌트 전반에 slugified name 적용
* `EtcOption`에서 텍스트 입력 제거 → 기타 체크 유무만 저장하도록 단순화
* `processDynamicFormData`에서 slugified key로 값 참조 후 원래 title로 매핑
* 모든 formatter (`Trainee`, `Standard`, `Survey`)에서 title → slugified key로 값 접근하도록 수정


## 🔀 변경사항

* `OptionContainer.tsx`: name 등록 시 `slugify(title)` 적용
* `SentenceOption.tsx`, `DropDownOption.tsx`, `CheckBoxOption.tsx` 등 옵션 컴포넌트: ref 등록 로직 안정화
* `EtcOption.tsx`: 기타 텍스트 입력 제거 → `"기타"`만 전송되도록 변경
* `processFormField.ts`: `etc` 입력값 처리 로직 제거
* `processDynamicFormData.ts`: key 참조 방식 `slugify`로 수정
* `createTraineeApplicationFormatter.ts`
* `createStandardApplicationFormatter.ts`
* `createSurveyFormatter.ts`

## 🍴 사용방법

1. 기존과 동일하게 폼 작성
2. 제출 시 `informationJson`, `answerJson`이 원래 title 기준으로 전송됨
3. 기타 입력란은 표시되지 않고 `"기타"` 선택만 저장됨


## 🎸 기타

* 이전에 발생하던 `_f` 관련 에러 재현 불가 상태로 안정화 확인됨
* 서버 API 전송 포맷은 기존과 동일하므로 백엔드 수정 없음
* 기타 입력값 제거 및 slugified 키 정리는 모두 사용자 경험과 안정성을 위한 사전 대응



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 문자열을 URL이나 식별자에 적합하도록 변환하는 slugify 기능이 추가되었습니다.

- **버그 수정**
  - 폼 데이터 처리 시 한글 라벨 대신 slugify된 키를 사용하여 데이터 접근의 일관성과 안정성이 향상되었습니다.

- **기능 개선**
  - '기타' 옵션 선택 시 추가 입력 필드 및 관련 동작이 제거되어 UI가 단순화되었습니다.
  - 문장형 입력의 최대 글자 수가 20자에서 500자로 확대되었습니다.
  - 폼 필드 처리 로직이 간소화되어 불필요한 조건 및 매개변수가 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->