### PR TITLE
Refector/qr scann

### DIFF
--- a/src/entities/name-tag/ui/NameTagHeader/index.tsx
+++ b/src/entities/name-tag/ui/NameTagHeader/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 const NameTagHeader = () => {
   return (
     <div className="flex items-center justify-between">
-      <p className="text-h2b text-black">참가자 명찰 인원</p>
+      <p className="text-h2b text-black">참가자 입장 조회</p>
     </div>
   );
 };

--- a/src/shared/model/useQRScanner.ts
+++ b/src/shared/model/useQRScanner.ts
@@ -1,12 +1,13 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { toast } from 'react-toastify';
 import { QrScanData } from '../types/common/QrScanData';
 
 export const useQRScanner = (
   setScannedQR: React.Dispatch<React.SetStateAction<QrScanData | null>>,
 ) => {
-  const [buffer, setBuffer] = useState<string>('');
-  const [isScanning, setIsScanning] = useState<boolean>(false);
+  const bufferRef = useRef<string>('');
+  const isScanningRef = useRef<boolean>(false);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const handleQRScan = useCallback(
     (cleanData: string) => {
@@ -22,32 +23,42 @@ export const useQRScanner = (
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (!isScanning) {
-        setIsScanning(true);
-        setBuffer('');
+      if (event.key.length !== 1 && event.key !== 'Enter') return;
+
+      if (!isScanningRef.current) {
+        isScanningRef.current = true;
+        bufferRef.current = '';
       }
 
       if (event.key === 'Enter') {
-        const cleanData = buffer.replace(/Shift/g, '');
+        const cleanData = bufferRef.current;
 
-        if (!/^[a-zA-Z0-9{}":,._[\]\s-]+$/.test(cleanData)) {
+        if (cleanData.length < 5) {
+          toast.warn('QR 코드 인식 실패: 데이터가 너무 짧습니다.');
+        } else if (!/^[a-zA-Z0-9{}":,._[\]\s-]+$/.test(cleanData)) {
           toast.warn('입력 언어를 영어로 변경해주세요.');
-          setBuffer('');
-          setIsScanning(false);
-          return;
+        } else {
+          handleQRScan(cleanData);
         }
 
-        handleQRScan(cleanData);
-        setBuffer('');
-        setIsScanning(false);
-      } else {
-        setBuffer((prev) => prev + event.key);
+        bufferRef.current = '';
+        isScanningRef.current = false;
+        return;
       }
+
+      bufferRef.current += event.key;
+
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => {
+        bufferRef.current = '';
+        isScanningRef.current = false;
+      }, 300);
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
-  }, [buffer, isScanning, handleQRScan]);
+  }, [handleQRScan]);
 };

--- a/src/shared/model/useQRScanner.ts
+++ b/src/shared/model/useQRScanner.ts
@@ -7,7 +7,7 @@ export const useQRScanner = (
 ) => {
   const bufferRef = useRef<string>('');
   const isScanningRef = useRef<boolean>(false);
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleQRScan = useCallback(
     (cleanData: string) => {
@@ -31,6 +31,11 @@ export const useQRScanner = (
       }
 
       if (event.key === 'Enter') {
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current);
+          timeoutRef.current = null;
+        }
+
         const cleanData = bufferRef.current;
 
         if (cleanData.length < 5) {

--- a/src/shared/ui/Table/TableForm/index.tsx
+++ b/src/shared/ui/Table/TableForm/index.tsx
@@ -34,7 +34,10 @@ const TableForm = <T extends { id: number }>({
       <div className="space-y-[30px] overflow-x-auto border-b-1 border-solid border-gray-100 pb-6">
         <div className="min-w-[800px]">
           <TableHeader categories={categories} />
-          <div className="space-y-20 overflow-y-auto" style={{ maxHeight }}>
+          <div
+            className="space-y-20 overflow-y-auto pt-6"
+            style={{ maxHeight }}
+          >
             {data.map((item, index) => (
               <TableItem
                 state={selectItem}

--- a/src/widgets/application/model/usePostApplication.ts
+++ b/src/widgets/application/model/usePostApplication.ts
@@ -46,11 +46,13 @@ export const usePostApplication = (
         applicationType === 'onsite' &&
         response &&
         response.participantId &&
-        response.phoneNumber
+        response.phoneNumber &&
+        response.expoId
       ) {
         const qrPayload = {
           participantId: response.participantId,
           phoneNumber: response.phoneNumber,
+          expoId: response.expoId,
         };
 
         const name = 'name' in variables ? variables.name : '이름 없음';

--- a/src/widgets/program-detail/ui/ProgramDetailForm/index.tsx
+++ b/src/widgets/program-detail/ui/ProgramDetailForm/index.tsx
@@ -75,6 +75,7 @@ const ProgramDetailForm = ({
           footerType="file"
           text="인원 수"
           actions={filteActions}
+          selectItemBoolean={false}
         />
       </div>
     ),


### PR DESCRIPTION
## 💡 배경 및 개요

기존 QR 스캐너 훅은 `buffer` 상태를 `useState`로 관리하면서 `keydown` 이벤트 처리 시점과 상태 업데이트 간의 비동기 타이밍 이슈로 인해 첫 스캔에서 JSON 파싱 오류가 발생하는 문제가 있었습니다.
또한 이벤트 리스너가 `buffer` 변경마다 재등록되는 구조로 되어 있어 불필요한 리렌더 및 예외 상황이 발생할 가능성이 존재했습니다.


## 📃 작업내용

* `buffer`, `isScanning` 상태를 `useRef`로 변경하여 비동기 상태 업데이트 문제 해결
* `keydown` 핸들러를 `useEffect` 내부에 1회만 등록되도록 리팩토링
* `Shift`, `Alt` 등의 조합키 입력 무시 (key.length !== 1)
* 입력 후 일정 시간(300ms) 이상 입력이 없을 경우 자동 초기화
* 입력 길이가 짧거나 JSON 형식이 아닌 경우 `toast`로 예외 처리


## 🔀 변경사항

* `useQRScanner` 훅 내부 로직 전반 개선
* 기존 `useState` 기반 입력 버퍼 → `useRef` 기반 변경
* 이벤트 등록/해제 방식 개선 및 안정화


## 🎸 기타

* QR 입력 시 `Enter` 기준으로만 스캔 완료되며, 그 외 일반 키 입력은 무조건 누적됩니다.
* 추후 `input` 또는 `div`에 포커스를 제한하는 방식도 고려 가능


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - QR 스캐너 입력 처리 시 불필요한 렌더링을 방지하고, 입력 유효성 검사 및 디바운스(300ms) 기능이 개선되었습니다.
  - QR 입력이 5자 미만이거나 잘못된 형식일 때 경고 메시지가 표시됩니다.

- **스타일**
  - 테이블 폼 상단에 여백이 추가되어 레이아웃이 개선되었습니다.

- **기능 개선**
  - 배지 출력 시 expoId가 추가로 확인되어 QR 코드 데이터에 포함됩니다.
  - 프로그램 상세 폼에서 테이블 폼에 새로운 불리언 속성이 적용되었습니다.

- **텍스트 변경**
  - 참가자 명찰 헤더의 문구가 "참가자 명찰 인원"에서 "참가자 입장 조회"로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->