### PR TITLE
폼 경고 메시지 설정

### DIFF
--- a/src/entities/application/ui/ApplicationPhoneOption/index.tsx
+++ b/src/entities/application/ui/ApplicationPhoneOption/index.tsx
@@ -15,6 +15,7 @@ interface Props {
   type: string;
   setValue: UseFormSetValue<ApplicationFormValues>;
   watch: UseFormWatch<ApplicationFormValues>;
+  warningMessage?: string | null;
 }
 
 export default function ApplicationPhoneOption({
@@ -26,6 +27,7 @@ export default function ApplicationPhoneOption({
   type,
   setValue,
   watch,
+  warningMessage,
 }: Props) {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const phoneNumberStatus = watch('phoneNumberStatus');
@@ -105,6 +107,9 @@ export default function ApplicationPhoneOption({
           <hr className="border-gray-100" />
         </div>
       )}
+      <p className="whitespace-pre-line text-body2r text-error mobile:text-caption2r">
+        {warningMessage}
+      </p>
     </div>
   );
 }

--- a/src/entities/application/ui/OptionContainer/index.tsx
+++ b/src/entities/application/ui/OptionContainer/index.tsx
@@ -23,6 +23,7 @@ interface OptionContainerProps {
   setValue: UseFormSetValue<ApplicationFormValues>;
   readOnly?: boolean;
   defaultValue?: string;
+  warningMessage?: string | null;
 }
 
 const OptionContainer = ({
@@ -37,6 +38,7 @@ const OptionContainer = ({
   setValue,
   readOnly = false,
   defaultValue = '',
+  warningMessage,
 }: OptionContainerProps) => {
   const safeName = slugify(title);
 
@@ -65,6 +67,7 @@ const OptionContainer = ({
           type={type}
           readOnly={readOnly}
           defaultValue={defaultValue}
+          warningMessage={warningMessage}
         />
       );
       break;
@@ -112,6 +115,7 @@ const OptionContainer = ({
           watch={watch}
           setValue={setValue}
           type={type}
+          warningMessage={warningMessage}
         />
       );
       break;

--- a/src/entities/application/ui/SentenceOption/index.tsx
+++ b/src/entities/application/ui/SentenceOption/index.tsx
@@ -11,6 +11,7 @@ interface Props {
   type?: string;
   readOnly?: boolean;
   defaultValue?: string;
+  warningMessage?: string | null;
 }
 
 export default function SentenceOption({
@@ -22,6 +23,7 @@ export default function SentenceOption({
   type,
   readOnly = false,
   defaultValue = '',
+  warningMessage,
 }: Props) {
   const { ref, onChange, ...rest } = register(name, {
     required: required ? '필수 옵션을 작성해주세요' : false,
@@ -75,6 +77,9 @@ export default function SentenceOption({
         />
       </div>
       <hr className="border-gray-100" />
+      <p className="whitespace-pre-line text-body2r text-error mobile:text-caption2r">
+        {warningMessage}
+      </p>
     </div>
   );
 }

--- a/src/widgets/application/model/getWarningMessage.ts
+++ b/src/widgets/application/model/getWarningMessage.ts
@@ -1,0 +1,12 @@
+export const getWarningMessage = (
+  formType: 'application' | 'survey' | null,
+  applicationType: 'register' | 'onsite' | null,
+): string | null => {
+  if (formType === 'application' && applicationType === 'register') {
+    return `• 같은 번호로는 중복 등록이 불가능해요\n• 휴대폰이 없으신 경우, 행사 당일 현장에서도 접수할 수 있어요`;
+  }
+  if (formType === 'application' && applicationType === 'onsite') {
+    return `• 같은 번호로는 중복 등록이 불가능해요\n• 휴대폰이 없으신 경우에는 임시 QR 발급을 도와드릴 수 있으니, 현장 관리자에게 말씀해주세요`;
+  }
+  return null;
+};

--- a/src/widgets/application/ui/ApplicationLayout/index.tsx
+++ b/src/widgets/application/ui/ApplicationLayout/index.tsx
@@ -16,6 +16,7 @@ import {
 import { Button, DetailHeader } from '@/shared/ui';
 import { getFormatter } from '../../model/formatterService';
 import { getHeaderTitle } from '../../model/getHeaderTitle';
+import { getWarningMessage } from '../../model/getWarningMessage';
 import { useGetForm } from '../../model/useGetForm';
 import { usePostApplication } from '../../model/usePostApplication';
 
@@ -132,6 +133,7 @@ const ApplicationLayout = ({ params }: { params: string }) => {
                 register={register}
                 watch={watch}
                 setValue={setValue}
+                warningMessage={getWarningMessage(formType, applicationType)}
               />
             ) : (
               <OptionContainer
@@ -145,6 +147,7 @@ const ApplicationLayout = ({ params }: { params: string }) => {
                 setValue={setValue}
                 readOnly={formType === 'survey' && !!phoneNumber}
                 defaultValue={phoneNumber ?? ''}
+                warningMessage={getWarningMessage(formType, applicationType)}
               />
             )}
 


### PR DESCRIPTION
## 💡 배경 및 개요

AI SW 체험축전 참가자를 위한 신청 폼에서, 휴대폰 번호 입력란에 사용자 안내 메시지를 조건별로 제공하기 위해 경고 메시지를 분리 및 개선했습니다.
이 메시지는 현재 하드코딩된 상태로, 축전 종료 이후에는 서버와 협의하여 유동적으로 관리할 수 있도록 개선이 필요합니다.

## 📃 작업내용

* `getWarningMessage(formType, applicationType)` 함수 분리
* `register` 및 `onsite` 신청 유형에 따라 다른 메시지 노출
* 기존 하드코딩된 메시지를 함수 기반으로 이동

## 🔀 변경사항

* `warningMessage` 문자열 조건 분기 → 유틸 함수로 모듈화
* 휴대폰 미소지자에 대한 메시지 표현을 더 부드럽게 변경

## 🙋‍♂️ 질문사항

* 추후 메시지를 서버에서 내려받는 형식으로 바꾸는 방향성에 대해 논의가 필요합니다. (ex: form metadata 내 포함 여부)

## 🍴 사용방법

기존과 동일하게 `OptionContainer` 컴포넌트 사용 시, `formType`과 `applicationType` 값에 따라 자동으로 메시지가 설정됩니다.

## 🎸 기타

* 현 구조상 `formType`과 `applicationType`이 없으면 메시지가 없도록 되어 있어, fallback 처리는 따로 하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - 휴대폰 번호 입력 옵션 및 문장 입력 옵션에 경고 메시지 표시 기능이 추가되었습니다.
    - 중복 등록 제한 등 상황에 따라 안내 메시지가 자동으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->