### PR TITLE
fix: maps object

### DIFF
--- a/src/entities/exhibition/model/useKakaoMap.ts
+++ b/src/entities/exhibition/model/useKakaoMap.ts
@@ -29,7 +29,7 @@ export const useKakaoMap = ({ latitude, longitude }: KakaoMapOptions) => {
 
   useEffect(() => {
     const initializeMap = () => {
-      if (typeof window.kakao !== 'undefined') {
+      if (typeof window.kakao !== 'undefined' && window.kakao.maps) {
         window.kakao.maps.load(() => {
           loadKakaoMap();
         });


### PR DESCRIPTION
## 💡 배경 및 개요

`/exhibition/detail/{id}` 페이지에 접근 시 
```
TypeError: Cannot read properties of undefined (reading 'load')
```
이와 같은 오류가 발생했습니다

## 📃 작업내용

Kakao Maps SDK가 완전히 로드되기 전에 maps에 접근하지 못하도록 수정했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 지도 API 초기화 시 안정성을 개선하여 필수 요소가 모두 준비된 후에만 로드되도록 수정했습니다.
  * API 로드 실패 시 오류 로그를 추가하여 문제 진단을 용이하게 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->