### PR TITLE
fix: isValidSrc 가 blob: URL을 체크하도록 수정했습니다

### DIFF
--- a/src/shared/model/isValidSrc.ts
+++ b/src/shared/model/isValidSrc.ts
@@ -3,6 +3,7 @@ export const isValidSrc = (src: string | null): boolean => {
   return (
     src.startsWith('/') ||
     src.startsWith('http://') ||
-    src.startsWith('https://')
+    src.startsWith('https://') ||
+    src.startsWith('blob:')
   );
 };


### PR DESCRIPTION
## 💡 배경 및 개요

resolve https://github.com/School-of-Company/Expo-Client/issues/208

## 📃 작업내용

isValidSrc 함수가 blob:으로 시작하는 URL을 인식하지 못하는 문제를 수정했습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Blob URL에 대한 지원이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->