### PR TITLE
Feat: 동적 폼 특수 질문 생성 기능 추가 

### DIFF
--- a/src/entities/form/index.ts
+++ b/src/entities/form/index.ts
@@ -10,4 +10,5 @@ export { default as CreateFormButton } from './ui/CreateFormButton';
 export { default as CheckBox } from './ui/CheckBox';
 export { default as PrivacyConsentForm } from './ui/PrivacyConsentForm';
 export { default as ConditionalSettings } from './ui/ConditionalSettings';
+export { default as SplitButton } from './ui/SplitButton';
 export { selectOptionData } from './constants/selectOptionData';

--- a/src/entities/form/ui/RequiredToggle/index.tsx
+++ b/src/entities/form/ui/RequiredToggle/index.tsx
@@ -5,9 +5,10 @@ import ToggleButton from '@/shared/ui/ToggleButton';
 interface Props {
   control: Control<FormValues>;
   index: number;
+  isLocked?: boolean;
 }
 
-const RequiredToggle = ({ control, index }: Props) => {
+const RequiredToggle = ({ control, index, isLocked = false }: Props) => {
   const { field } = useController({
     name: `questions.${index}.requiredStatus`,
     control,
@@ -17,7 +18,11 @@ const RequiredToggle = ({ control, index }: Props) => {
   return (
     <label className="flex items-center gap-8">
       <p className="text-caption1r text-black mobile:text-caption2r">필수</p>
-      <ToggleButton value={field.value ?? false} onChange={field.onChange} />
+      <ToggleButton
+        value={isLocked ? true : (field.value ?? false)}
+        onChange={isLocked ? () => {} : field.onChange}
+        disabled={isLocked}
+      />
     </label>
   );
 };

--- a/src/entities/form/ui/SplitButton/index.tsx
+++ b/src/entities/form/ui/SplitButton/index.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { Plus, ArrowDown } from '@/shared/assets/icons';
+
+export type DynamicFormType = 'NAME' | 'PHONE_NUMBER' | 'TRAINEE_ID';
+
+interface SplitButtonProps {
+  onDefaultClick: () => void;
+  onSpecialFieldClick: (type: DynamicFormType) => void;
+  text?: string;
+  disabledOptions?: Set<string>;
+}
+
+const SPECIAL_FIELD_OPTIONS: { value: DynamicFormType; label: string }[] = [
+  { value: 'NAME', label: '이름' },
+  { value: 'PHONE_NUMBER', label: '전화번호' },
+  { value: 'TRAINEE_ID', label: '연수자아이디' },
+];
+
+const SplitButton = ({
+  onDefaultClick,
+  onSpecialFieldClick,
+  text = '추가하기',
+  disabledOptions = new Set(),
+}: SplitButtonProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  const handleSpecialFieldClick = (type: DynamicFormType) => {
+    if (!disabledOptions.has(type)) {
+      onSpecialFieldClick(type);
+      setIsOpen(false);
+    }
+  };
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <div className="flex items-center">
+        <button
+          type="button"
+          onClick={onDefaultClick}
+          className="flex items-center gap-12 rounded-l-sm bg-main-100 px-16 py-12"
+        >
+          <Plus fill="#448FFF" />
+          <p className="text-body2r text-main-600">{text}</p>
+        </button>
+
+        <button
+          type="button"
+          onClick={() => setIsOpen(!isOpen)}
+          className="flex items-center rounded-r-sm bg-main-100 px-8 py-12"
+        >
+          <ArrowDown fill="#448FFF" />
+        </button>
+      </div>
+
+      {isOpen && (
+        <div className="absolute bottom-full left-0 z-10 mb-4 w-full min-w-[160px] rounded-sm border-1 border-solid border-gray-200 bg-white shadow-lg">
+          {SPECIAL_FIELD_OPTIONS.map((option) => {
+            const isDisabled = disabledOptions.has(option.value);
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => handleSpecialFieldClick(option.value)}
+                disabled={isDisabled}
+                className={`w-full px-16 py-12 text-left text-body2r first:rounded-t-sm last:rounded-b-sm ${
+                  isDisabled
+                    ? 'cursor-not-allowed text-gray-400 opacity-50'
+                    : 'text-gray-900 hover:bg-gray-50'
+                }`}
+              >
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SplitButton;

--- a/src/entities/form/ui/SplitButton/index.tsx
+++ b/src/entities/form/ui/SplitButton/index.tsx
@@ -2,8 +2,7 @@
 
 import { useState, useRef, useEffect } from 'react';
 import { Plus, ArrowDown } from '@/shared/assets/icons';
-
-export type DynamicFormType = 'NAME' | 'PHONE_NUMBER' | 'TRAINEE_ID';
+import { DynamicFormType } from '@/shared/types/form/create/type';
 
 interface SplitButtonProps {
   onDefaultClick: () => void;

--- a/src/features/application/api/postTrainingProgramSelection.ts
+++ b/src/features/application/api/postTrainingProgramSelection.ts
@@ -2,9 +2,12 @@ import axios from 'axios';
 import clientInstance from '@/shared/libs/http/clientInstance';
 
 export interface TrainingProgramSelectionRequest {
+  name: string;
+  phoneNumber: string;
+  trainingId: string;
   informationJson: string;
   personalInformationStatus: boolean;
-  trainingProIds: number[];
+  trainingProId: number[];
 }
 
 export const postTrainingProgramSelection = async (

--- a/src/features/application/lib/extractTrainingProgramData.ts
+++ b/src/features/application/lib/extractTrainingProgramData.ts
@@ -43,10 +43,13 @@ export const extractTrainingProgramData = async (
 
   if (trainingProIds.length > 0) {
     return {
+      name: formattedData.name || '',
+      phoneNumber: formattedData.phoneNumber || '',
+      trainingId: formattedData.trainingId || '',
       informationJson: formattedData.informationJson,
       personalInformationStatus:
         formattedData.personalInformationStatus ?? false,
-      trainingProIds,
+      trainingProId: trainingProIds,
     };
   }
 

--- a/src/features/application/lib/formatter/createStandardApplicationFormatter.ts
+++ b/src/features/application/lib/formatter/createStandardApplicationFormatter.ts
@@ -16,27 +16,20 @@ export const createStandardApplicationFormatter = (
   ): FormattedApplicationData => {
     const processedData = processDynamicFormData(data, dynamicFormItems);
 
+    const nameField = dynamicFormItems.find(
+      (item) => item.dynamicFormType === 'NAME',
+    );
+
     let nameValue: string | undefined;
     let informationJsonData = processedData;
 
-    if (applicationType === 'FIELD') {
-      const nameField = dynamicFormItems.find((item) =>
-        item.title.includes('성명'),
-      );
+    if (nameField) {
+      nameValue = data[slugify(nameField.title)] as string | undefined;
 
-      if (nameField) {
-        nameValue = data[slugify(nameField.title)] as string | undefined;
-
+      if (applicationType === 'FIELD') {
         const { [nameField.title]: _, ...rest } = processedData;
         informationJsonData = rest;
       }
-    } else {
-      const nameField = dynamicFormItems.find((item) =>
-        item.title.includes('이름'),
-      );
-      nameValue = nameField
-        ? (data[slugify(nameField.title)] as string | undefined)
-        : undefined;
     }
 
     return {

--- a/src/features/application/lib/formatter/createSurveyFormatter.ts
+++ b/src/features/application/lib/formatter/createSurveyFormatter.ts
@@ -13,9 +13,13 @@ export const createSurveyFormatter = (
   data: DynamicFormValues & { privacyConsent: boolean },
 ) => FormattedSurveyData) => {
   return (data) => {
-    const phoneNumberKey = slugify('휴대폰 번호를 입력하세요');
+    const phoneField = dynamicFormItems.find(
+      (item) => item.dynamicFormType === 'PHONE_NUMBER',
+    );
 
-    const phoneNumber = queryPhoneNumber || String(data[phoneNumberKey] || '');
+    const phoneNumber =
+      queryPhoneNumber ||
+      (phoneField ? String(data[slugify(phoneField.title)] || '') : '');
 
     return {
       phoneNumber,

--- a/src/features/application/lib/formatter/createTraineeApplicationFormatter.ts
+++ b/src/features/application/lib/formatter/createTraineeApplicationFormatter.ts
@@ -1,3 +1,4 @@
+import { slugify } from '@/shared/model';
 import {
   DynamicFormItem,
   DynamicFormValues,
@@ -15,8 +16,33 @@ export const createTraineeApplicationFormatter = (
   return (
     data: DynamicFormValues & { privacyConsent: boolean },
   ): FormattedApplicationData => {
+    const nameField = dynamicFormItems.find(
+      (item) => item.dynamicFormType === 'NAME',
+    );
+    const nameValue = nameField
+      ? (data[slugify(nameField.title)] as string | undefined)
+      : undefined;
+
+    const phoneField = dynamicFormItems.find(
+      (item) => item.dynamicFormType === 'PHONE_NUMBER',
+    );
+    const phoneValue = phoneField
+      ? (data[slugify(phoneField.title)] as string | undefined)
+      : undefined;
+
+    const traineeIdField = dynamicFormItems.find(
+      (item) => item.dynamicFormType === 'TRAINEE_ID',
+    );
+    const traineeIdValue = traineeIdField
+      ? (data[slugify(traineeIdField.title)] as string | undefined)
+      : undefined;
+
     const filteredFormItems = dynamicFormItems.filter(
-      (item) => !shouldExcludeTrainingProgramQuestion(item.title),
+      (item) =>
+        !shouldExcludeTrainingProgramQuestion(item.title) &&
+        item.dynamicFormType !== 'NAME' &&
+        item.dynamicFormType !== 'PHONE_NUMBER' &&
+        item.dynamicFormType !== 'TRAINEE_ID',
     );
 
     return {
@@ -26,6 +52,9 @@ export const createTraineeApplicationFormatter = (
       ...(data.privacyConsent !== undefined && {
         personalInformationStatus: data.privacyConsent,
       }),
+      ...(nameValue && { name: nameValue }),
+      ...(phoneValue && { phoneNumber: phoneValue }),
+      ...(traineeIdValue && { trainingId: traineeIdValue }),
     };
   };
 };

--- a/src/features/form/common/model/formUtils.ts
+++ b/src/features/form/common/model/formUtils.ts
@@ -42,6 +42,7 @@ const getSurveyRequestData = (
       jsonData: convertOptionsToJson(question.options),
       requiredStatus: question.requiredStatus,
       otherJson: question.otherJson,
+      dynamicFormType: question.dynamicFormType || 'DEFAULT',
     })),
   };
 };
@@ -72,6 +73,7 @@ const getApplicationRequestData = (
       jsonData: convertOptionsToJson(question.options),
       requiredStatus: question.requiredStatus,
       otherJson: question.otherJson,
+      dynamicFormType: question.dynamicFormType || 'DEFAULT',
     })),
   };
 };

--- a/src/features/form/common/ui/FormContainer/index.tsx
+++ b/src/features/form/common/ui/FormContainer/index.tsx
@@ -57,6 +57,11 @@ const FormContainer = ({
     name: `questions.${index}.title`,
   });
 
+  const dynamicFormType = useWatch({
+    control,
+    name: `questions.${index}.dynamicFormType`,
+  });
+
   const { fields, append, remove } = useFieldArray({
     control,
     name: `questions.${index}.options`,
@@ -64,6 +69,11 @@ const FormContainer = ({
 
   const isTrainingProgramQuestion =
     questionTitle?.includes('연수 프로그램을 선택해주세요');
+
+  const isSpecialField =
+    dynamicFormType === 'NAME' ||
+    dynamicFormType === 'PHONE_NUMBER' ||
+    dynamicFormType === 'TRAINEE_ID';
 
   const componentMap: Record<string, JSX.Element | null> = {
     CHECKBOX: (
@@ -144,6 +154,13 @@ const FormContainer = ({
     }
   }, [selectedOption, index, setValue]);
 
+  // Set required status to true for special fields
+  useEffect(() => {
+    if (isSpecialField) {
+      setValue(`questions.${index}.requiredStatus`, true);
+    }
+  }, [isSpecialField, index, setValue]);
+
   return (
     <div
       className={`flex w-full flex-col gap-20 rounded-sm border-1 border-solid border-gray-200 px-32 py-18`}
@@ -199,14 +216,20 @@ const FormContainer = ({
             formRemove(index);
           }}
         />
-        <RequiredToggle control={control} index={index} />
+        <RequiredToggle
+          control={control}
+          index={index}
+          isLocked={isSpecialField}
+        />
       </div>
 
-      <ConditionalSettings
-        currentIndex={index}
-        control={control}
-        setValue={setValue}
-      />
+      {!isSpecialField && (
+        <ConditionalSettings
+          currentIndex={index}
+          control={control}
+          setValue={setValue}
+        />
+      )}
     </div>
   );
 };

--- a/src/features/form/common/ui/FormEditor/index.tsx
+++ b/src/features/form/common/ui/FormEditor/index.tsx
@@ -10,11 +10,9 @@ import {
   SplitButton,
 } from '@/entities/form';
 import { handleFormErrors } from '@/shared/model';
-import { FormValues } from '@/shared/types/form/create/type';
+import { DynamicFormType, FormValues } from '@/shared/types/form/create/type';
 import { Button, DetailHeaderEditable } from '@/shared/ui';
 import FormContainer from '../FormContainer';
-
-type DynamicFormType = 'NAME' | 'PHONE_NUMBER' | 'TRAINEE_ID';
 
 const FormEditor = ({
   expoId,
@@ -102,8 +100,8 @@ const FormEditor = ({
       )
       .map((q) => q.dynamicFormType)
       .filter(
-        (type): type is 'NAME' | 'PHONE_NUMBER' | 'TRAINEE_ID' =>
-          type !== undefined,
+        (type): type is DynamicFormType =>
+          type !== undefined && type !== 'DEFAULT',
       ) || [],
   );
 

--- a/src/features/form/common/ui/FormEditor/index.tsx
+++ b/src/features/form/common/ui/FormEditor/index.tsx
@@ -43,7 +43,7 @@ const FormEditor = ({
     !!defaultValues?.informationText,
   );
 
-  const questions = watch('questions');
+  const questions = watch('questions') ?? [];
 
   const handleFormSubmit = (data: FormValues) => {
     const submitData = {
@@ -92,7 +92,7 @@ const FormEditor = ({
 
   const usedSpecialFieldTypes = new Set(
     questions
-      ?.filter(
+      .filter(
         (q) =>
           q.dynamicFormType === 'NAME' ||
           q.dynamicFormType === 'PHONE_NUMBER' ||
@@ -102,7 +102,7 @@ const FormEditor = ({
       .filter(
         (type): type is DynamicFormType =>
           type !== undefined && type !== 'DEFAULT',
-      ) || [],
+      ),
   );
 
   const filteredSelectOptions = selectOptionData.filter(

--- a/src/features/form/common/ui/FormEditor/index.tsx
+++ b/src/features/form/common/ui/FormEditor/index.tsx
@@ -7,11 +7,14 @@ import {
   CreateFormButton,
   PrivacyConsentForm,
   selectOptionData,
+  SplitButton,
 } from '@/entities/form';
 import { handleFormErrors } from '@/shared/model';
 import { FormValues } from '@/shared/types/form/create/type';
 import { Button, DetailHeaderEditable } from '@/shared/ui';
 import FormContainer from '../FormContainer';
+
+type DynamicFormType = 'NAME' | 'PHONE_NUMBER' | 'TRAINEE_ID';
 
 const FormEditor = ({
   expoId,
@@ -42,6 +45,8 @@ const FormEditor = ({
     !!defaultValues?.informationText,
   );
 
+  const questions = watch('questions');
+
   const handleFormSubmit = (data: FormValues) => {
     const submitData = {
       ...data,
@@ -59,6 +64,48 @@ const FormEditor = ({
     setHasPrivacyConsent(false);
     setValue('informationText', '');
   };
+
+  const handleAddDefaultField = () => {
+    append({
+      title: '',
+      formType: 'SENTENCE',
+      options: [],
+      requiredStatus: false,
+      otherJson: null,
+      dynamicFormType: 'DEFAULT',
+    });
+  };
+
+  const handleAddSpecialField = (type: DynamicFormType) => {
+    const fieldConfig = {
+      NAME: { title: '이름', formType: 'SENTENCE' },
+      PHONE_NUMBER: { title: '전화번호', formType: 'SENTENCE' },
+      TRAINEE_ID: { title: '연수자아이디', formType: 'SENTENCE' },
+    };
+
+    append({
+      ...fieldConfig[type],
+      options: [],
+      requiredStatus: false,
+      otherJson: null,
+      dynamicFormType: type,
+    });
+  };
+
+  const usedSpecialFieldTypes = new Set(
+    questions
+      ?.filter(
+        (q) =>
+          q.dynamicFormType === 'NAME' ||
+          q.dynamicFormType === 'PHONE_NUMBER' ||
+          q.dynamicFormType === 'TRAINEE_ID',
+      )
+      .map((q) => q.dynamicFormType)
+      .filter(
+        (type): type is 'NAME' | 'PHONE_NUMBER' | 'TRAINEE_ID' =>
+          type !== undefined,
+      ) || [],
+  );
 
   const filteredSelectOptions = selectOptionData.filter(
     (option) => option.value !== 'PRIVACYCONSENT',
@@ -109,16 +156,10 @@ const FormEditor = ({
               )}
             </div>
             <div className="flex gap-12">
-              <CreateFormButton
-                onClick={() =>
-                  append({
-                    title: '',
-                    formType: 'SENTENCE',
-                    options: [],
-                    requiredStatus: false,
-                    otherJson: null,
-                  })
-                }
+              <SplitButton
+                onDefaultClick={handleAddDefaultField}
+                onSpecialFieldClick={handleAddSpecialField}
+                disabledOptions={usedSpecialFieldTypes}
               />
               {!hasPrivacyConsent && (
                 <CreateFormButton

--- a/src/features/form/edit/model/transformServerData.ts
+++ b/src/features/form/edit/model/transformServerData.ts
@@ -1,5 +1,9 @@
 import { ApplicationForm } from '@/shared/types/application/type';
-import { FormValues, Option } from '@/shared/types/form/create/type';
+import {
+  DynamicFormType,
+  FormValues,
+  Option,
+} from '@/shared/types/form/create/type';
 
 export const transformServerData = (
   data: ApplicationForm,
@@ -57,9 +61,7 @@ export const transformServerData = (
         requiredStatus: item.requiredStatus,
         otherJson: item.otherJson,
         dynamicFormType: (item.dynamicFormType || 'DEFAULT') as
-          | 'NAME'
-          | 'PHONE_NUMBER'
-          | 'TRAINEE_ID'
+          | DynamicFormType
           | 'DEFAULT',
       };
     }),

--- a/src/features/form/edit/model/transformServerData.ts
+++ b/src/features/form/edit/model/transformServerData.ts
@@ -56,6 +56,11 @@ export const transformServerData = (
         }),
         requiredStatus: item.requiredStatus,
         otherJson: item.otherJson,
+        dynamicFormType: (item.dynamicFormType || 'DEFAULT') as
+          | 'NAME'
+          | 'PHONE_NUMBER'
+          | 'TRAINEE_ID'
+          | 'DEFAULT',
       };
     }),
   };

--- a/src/features/form/edit/model/transformServerData.ts
+++ b/src/features/form/edit/model/transformServerData.ts
@@ -1,9 +1,5 @@
 import { ApplicationForm } from '@/shared/types/application/type';
-import {
-  DynamicFormType,
-  FormValues,
-  Option,
-} from '@/shared/types/form/create/type';
+import { FormValues, Option } from '@/shared/types/form/create/type';
 
 export const transformServerData = (
   data: ApplicationForm,
@@ -60,9 +56,7 @@ export const transformServerData = (
         }),
         requiredStatus: item.requiredStatus,
         otherJson: item.otherJson,
-        dynamicFormType: (item.dynamicFormType || 'DEFAULT') as
-          | DynamicFormType
-          | 'DEFAULT',
+        dynamicFormType: item.dynamicFormType || 'DEFAULT',
       };
     }),
   };

--- a/src/shared/types/application/type.ts
+++ b/src/shared/types/application/type.ts
@@ -32,6 +32,8 @@ export type FormattedApplicationData = {
   informationJson: string;
   personalInformationStatus?: boolean;
   name?: string;
+  phoneNumber?: string;
+  trainingId?: string;
 };
 
 export interface FormattedSurveyData {

--- a/src/shared/types/application/type.ts
+++ b/src/shared/types/application/type.ts
@@ -1,3 +1,5 @@
+import { DynamicFormType } from '../form/create/type';
+
 export interface DynamicFormItem {
   title: string;
   formType:
@@ -9,7 +11,7 @@ export interface DynamicFormItem {
   jsonData?: Record<string, string>;
   requiredStatus: boolean;
   otherJson: string | null;
-  dynamicFormType?: string;
+  dynamicFormType?: DynamicFormType | 'DEFAULT';
 }
 
 export interface ApplicationForm {

--- a/src/shared/types/application/type.ts
+++ b/src/shared/types/application/type.ts
@@ -9,6 +9,7 @@ export interface DynamicFormItem {
   jsonData?: Record<string, string>;
   requiredStatus: boolean;
   otherJson: string | null;
+  dynamicFormType?: string;
 }
 
 export interface ApplicationForm {

--- a/src/shared/types/form/create/type.ts
+++ b/src/shared/types/form/create/type.ts
@@ -9,6 +9,8 @@ export interface Option {
   isAlwaysSelected?: boolean;
 }
 
+export type DynamicFormType = 'NAME' | 'PHONE_NUMBER' | 'TRAINEE_ID';
+
 export interface FormValues {
   questions: {
     title: string;
@@ -16,7 +18,7 @@ export interface FormValues {
     options: Option[];
     requiredStatus: boolean;
     otherJson: string | null;
-    dynamicFormType?: 'NAME' | 'PHONE_NUMBER' | 'TRAINEE_ID' | 'DEFAULT';
+    dynamicFormType?: DynamicFormType | 'DEFAULT';
   }[];
   informationText: string;
   title: string;

--- a/src/shared/types/form/create/type.ts
+++ b/src/shared/types/form/create/type.ts
@@ -16,6 +16,7 @@ export interface FormValues {
     options: Option[];
     requiredStatus: boolean;
     otherJson: string | null;
+    dynamicFormType?: 'NAME' | 'PHONE_NUMBER' | 'TRAINEE_ID' | 'DEFAULT';
   }[];
   informationText: string;
   title: string;
@@ -49,6 +50,7 @@ export interface ApplicationFormRequest {
     jsonData: string;
     requiredStatus: boolean;
     otherJson: string | null;
+    dynamicFormType: string;
   }[];
   informationText: string;
   title: string;
@@ -64,6 +66,7 @@ export interface SurveyFormRequest {
     jsonData: string;
     requiredStatus: boolean;
     otherJson: string | null;
+    dynamicFormType: string;
   }[];
   informationText: string;
   title: string;

--- a/src/shared/ui/ToggleButton/index.tsx
+++ b/src/shared/ui/ToggleButton/index.tsx
@@ -3,21 +3,23 @@ import { preventEvent } from '@/shared/model';
 interface Props {
   value: boolean;
   onChange: (newValue: boolean) => void;
+  disabled?: boolean;
 }
 
-const ToggleButton = ({ value, onChange }: Props) => {
+const ToggleButton = ({ value, onChange, disabled = false }: Props) => {
   const toggle = (e: React.MouseEvent) => {
     preventEvent(e);
-    onChange(!value);
+    if (!disabled) onChange(!value);
   };
 
   return (
     <button
       type="button"
       onClick={toggle}
+      disabled={disabled}
       className={`relative inline-flex h-16 w-50 items-center rounded-full transition-colors ${
         value ? 'bg-main-100' : 'bg-gray-100'
-      }`}
+      } ${disabled ? 'cursor-not-allowed opacity-60' : ''}`}
     >
       <span
         className={`absolute left-0 h-20 w-20 rounded-full transition-transform duration-300 ${


### PR DESCRIPTION

## 📃 작업내용

이름, 전화번호, 연수자아이디에 대해서만 특수 폼을 추가할 수 있도록 했습니다

<img width="166" height="204" alt="스크린샷 2025-11-25 오후 6 21 50" src="https://github.com/user-attachments/assets/4c01f280-548d-4162-996c-88c0e978b6fd" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 폼 필드 추가에 기본 액션과 특수 옵션(이름·전화번호·교육생 ID)을 선택할 수 있는 분할 버튼(SplitButton) 추가
  * 특정 특수 필드를 항상 필수로 고정하는 잠금 옵션(isLocked) 추가

* **개선사항**
  * 토글 버튼에 비활성화(disabled) 상태 지원 추가
  * 동적 폼 타입과 관련 데이터·요청 구조에 대한 처리 보강(특수 필드 식별 및 추가 정보(name, phoneNumber, trainingId) 포함)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->